### PR TITLE
ee_test: Search for jenkins-env in the parent directory

### DIFF
--- a/ee_tests/cico_run_EE_tests.sh
+++ b/ee_tests/cico_run_EE_tests.sh
@@ -7,8 +7,8 @@ set -e
 
 # Source environment variables of the jenkins slave
 # that might interest this worker.
-if [ -e "jenkins-env" ]; then
-  cat jenkins-env \
+if [ -e "../jenkins-env" ]; then
+  cat ../jenkins-env \
     | grep -E "(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId|EE_TEST_USERNAME|EE_TEST_PASSWORD)=" \
     | sed 's/^/export /g' \
     > /tmp/jenkins-env


### PR DESCRIPTION
In the jenkins job, we have to move one level down inside the payload directory which might contain the jenkins-env file. https://github.com/almighty/almighty-jobs/blob/master/devtools-ci-index.yaml#L865