### PR TITLE
default to /tests as the working directory

### DIFF
--- a/EE_API_automation/pyresttest/Dockerfile
+++ b/EE_API_automation/pyresttest/Dockerfile
@@ -33,11 +33,8 @@ RUN cd /tmp \
   && cd pyresttest \
   && python setup.py install 
 
-RUN useradd -s /bin/bash ${F8_USER_NAME}
-
-# From here onwards, any RUN, CMD, or ENTRYPOINT
-# will be run under the following user
+RUN useradd --home-dir /tests -s /bin/bash ${F8_USER_NAME}
 USER ${F8_USER_NAME}
-
+WORKDIR /tests
+VOLUME ["/tests"]
 ENTRYPOINT ["pyresttest"]
-


### PR DESCRIPTION
This is a fixup for #102.

In order to avoid to having to modify paths in YAML files (e.g. `- import:  get_a_space.yaml`) we default to the `/tests` working directory where you should volume mount your tests.

Now you can use the `Dockerfile` like so:

```
$ cd EE_API_automation/pyresttest
$ docker build -t ee . -f Dockerfile
$ docker run --rm -it -v $PWD:/tests:ro ee https://api.openshift.io API_automation_workshop.yaml --vars="{'token':'YOUR_TOKEN', 'userid':'USERNAME'}" --interactive true
```