### PR TITLE
Replace nc with curl because is more portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ webdriver-manager update --versions.chrome 2.29
 .sh ./local_run_EE_tests.sh USERNAME PASSWORD openShiftToken OSIOtoken https://openshift.io testSuiteName githubUsername
 ```
 
-> Note: for macOS users, make sure you installed `nc` with `brew install netcat` prior launching the script. Also note that since the test scripts are primarily run on Centocs CI, they assume/require that a copy of the OpenShift client (oc) is installed int he tests' local directory. 
+> Note: Note that since the test scripts are primarily run on Centocs CI, they assume/require that a copy of the OpenShift client (oc) is installed int he tests' local directory. 
 
 * Run on prod
 

--- a/ee_tests/local_run_EE_tests.sh
+++ b/ee_tests/local_run_EE_tests.sh
@@ -31,7 +31,7 @@ echo -n Starting Webdriver and Selenium...
 (webdriver-manager start --versions.chrome 2.29 >>$LOGFILE 2>&1 &)
 
 # Wait for port 4444 to be listening connections
-while ! (nc -w 1 127.0.0.1 4444 </dev/null >/dev/null 2>&1); do sleep 1; done
+until curl --output /dev/null --silent --head --fail 127.0.0.1:4444; do sleep 1; done
 echo done.
 
 PROTRACTOR_JS="$PROTRACTOR_CONFIG_JS"
@@ -43,7 +43,7 @@ fi
 echo Running protractor test suite ${PROTRACTOR_JS} ...
 #node_modules/protractor/bin/protractor ${PROTRACTOR_JS} --suite setupTest --params.login.user=$1 --params.login.password=$2 --params.target.url=$3 --params.oso.token=$4 --params.kc.token=$5
 
-node_modules/protractor/bin/protractor ${PROTRACTOR_JS} --suite $TEST_SUITE --params.login.user=$1 --params.login.password=$2 --params.target.url=$3 --params.oso.token=$4 --params.kc.token=$5 --params.github.username=$GITHUB_USERNAME
+node_modules/protractor/bin/protractor ${PROTRACTOR_JS} --suite "${TEST_SUITE}" --params.login.user="${1}" --params.login.password="${2}" --params.target.url="${3}" --params.oso.token="${4}" --params.kc.token="${5}" --params.github.username="${GITHUB_USERNAME}"
 
 TEST_RESULT=$?
 


### PR DESCRIPTION
Depending on the platform there are [distinct flavours of netcat](http://xed.ch/h/nc.html). Each one 
 behave in a different way (e.g. on a Mac where, nc BSD is installed by default, the script `local_run_EE_tests.sh` hanged). That makes netcat less portable than curl that instead is consistent on any platform.

I have also fixed some warnings found running [`shellcheck`](https://github.com/koalaman/shellcheck).