### PR TITLE
Share common validation and webdriver functions

### DIFF
--- a/ee_tests/common.inc.sh
+++ b/ee_tests/common.inc.sh
@@ -4,3 +4,45 @@ source "$current_dir/lib/core.inc.sh"
 source "$current_dir/lib/logger.inc.sh"
 source "$current_dir/lib/script.inc.sh"
 unset current_dir
+
+start_webdriver() {
+  local log_file="$1"; shift
+
+  # Start selenium server just for this test run
+  log.info "Starting Webdriver and Selenium..."
+  log.info "Webdriver will log to:$GREEN $log_file"
+
+  npm run webdriver:start >> "$log_file" 2>&1 &
+}
+
+webdriver_running() {
+  curl --output /dev/null --silent --head --fail 127.0.0.1:4444
+}
+
+wait_for_webdriver() {
+  log.info "Waiting for the webdriver to start ..."
+
+  # Wait for port 4444 to be listening connections
+  ##### while ! (nc -w 1 127.0.0.1 4444 </dev/null >/dev/null 2>&1); do sleep 1; done
+
+  until webdriver_running ; do
+    sleep 1
+    echo -n .
+  done
+
+  echo
+  log.info "Webdriver manager up and running $GREEN OK"
+
+  # Cleanup webdriver-manager and web app processes
+  script.on_exit fuser -k -n tcp 4444
+  script.on_exit fuser -k -n tcp 8088
+}
+
+validate_test_config() {
+  local key="$1"; shift
+  local value="${1:-}"; shift
+
+  has_value "$value" && return 0
+  log.error "invalid test config ${GREEN}$key${RESET}: $YELLOW'$value'${RESET}"
+  return 1
+}

--- a/ee_tests/local_run_EE_tests.sh
+++ b/ee_tests/local_run_EE_tests.sh
@@ -7,49 +7,6 @@ declare -r SCRIPT_DIR=$(cd $(dirname "$SCRIPT_PATH") && pwd)
 
 source "$SCRIPT_DIR/common.inc.sh"
 
-start_webdriver() {
-  local log_file="$1"; shift
-
-  # Start selenium server just for this test run
-  log.info "Starting Webdriver and Selenium..."
-  log.info "Webdriver will log to:$GREEN $log_file"
-
-  npm run webdriver:start >> "$log_file" 2>&1 &
-}
-
-webdriver_running() {
-  curl --output /dev/null --silent --head --fail 127.0.0.1:4444
-}
-
-wait_for_webdriver() {
-  log.info "Waiting for the webdriver to start ..."
-
-  # Wait for port 4444 to be listening connections
-  ##### while ! (nc -w 1 127.0.0.1 4444 </dev/null >/dev/null 2>&1); do sleep 1; done
-
-  until webdriver_running ; do
-    sleep 1
-    echo -n .
-  done
-
-  echo
-  log.info "Webdriver manager up and running $GREEN OK"
-
-  # Cleanup webdriver-manager and web app processes
-  script.on_exit fuser -k -n tcp 4444
-  script.on_exit fuser -k -n tcp 8088
-}
-
-validate_test_config() {
-  local key="$1"; shift
-  local value="${1:-}"; shift
-
-  has_value "$value" && return 0
-  log.error "invalid test config ${GREEN}$key${RESET}: $YELLOW'$value'${RESET}"
-  return 1
-}
-
-
 
 validate_config() {
   local ret=0
@@ -101,8 +58,11 @@ main() {
 
   local log_file="${SCRIPT_DIR}/functional_tests.log"
 
-  start_webdriver "$log_file"
-  wait_for_webdriver
+  # NOTE: DO NOT start and kill webdriver if it is already running
+  webdriver_running || {
+    start_webdriver "$log_file"
+    wait_for_webdriver
+  }
 
   # Finally run protractor
   log.info Running protractor test suite "$PROTRACTOR_CONFIG_JS" \


### PR DESCRIPTION
This patch refactors the common code used in ts-protractor.sh and
local_run_EE_tests.sh to common.inc.sh.

The ts-protractor.sh now starts the webdriver if it isn't running
already and runs tsc to compile typescript to js before running
the tests.