### PR TITLE
local_run_EE_test: fix crash when CAT_LOGFILE is undefined

### DIFF
--- a/ee_tests/local_run_EE_tests.sh
+++ b/ee_tests/local_run_EE_tests.sh
@@ -83,7 +83,7 @@ main() {
     --params.oso.username="${OSO_USERNAME}"
   local test_result=$?
 
-  [[ "$CAT_LOGFILE" == "true" ]]&& show_logs "$log_file"
+  [[ "${CAT_LOGFILE:-false}" == "true" ]] && show_logs "$log_file"
 
 
   # Return test result


### PR DESCRIPTION
The script crashed when it evaluation [[ $CAT_LOGFILE == 'true' ]]
and CAT_LOGFILE wasn't defined. Since CAT_LOGFILE is optional, this
patch fixes it by setting the default to 'false'