### PR TITLE
MainDashboard: wait for the page url to change

### DIFF
--- a/ee_tests/src/specs/page_objects/main_dashboard.page.ts
+++ b/ee_tests/src/specs/page_objects/main_dashboard.page.ts
@@ -141,4 +141,11 @@ Page layout
     return spaceDashboard;
   }
 
+  async ready() {
+    // ensure that the _gettingStarted Page is gone before checking for
+    // headers and dropdown
+    await browser.wait(until.urlContains(this.url), support.minutes(2));
+    super.ready()
+  }
+
 }


### PR DESCRIPTION
The time taken for the main-dashboard page to load seems to have
increased. This patch waits for the 'getting started' page to
change (by waiting for the url to change) before checking if the
header and navigation bar are present.

(cherry picked from commit 4d3b5b778621aed8061c8c5b6065aa7f6f315f6d)