### PR TITLE
fix(pytest): Add json2env script which converts JSON file to env variables

### DIFF
--- a/EE_API_automation/pytest/json2env
+++ b/EE_API_automation/pytest/json2env
@@ -1,0 +1,7 @@
+# Bash script to convert json file to environment variables
+# How to use: eval $(cat file.json | json2env)
+
+#!/bin/sh
+tr -d '\n' |
+  grep -o '"[A-Za-z_][A-Za-z_0-9]\+"\s*:\s*\("[^"]\+"\|[0-9\.]\+\|true\|false\|null\)' |
+  sed 's/"\(.*\)"\s*:\s*"\?\([^"]\+\)"\?/export \U\1\E="\2"/'


### PR DESCRIPTION
How to use - `eval $(cat file.json | ./json2env)`