### PR TITLE
refactor(test): quickstart selection refactored

### DIFF
--- a/ee_tests/src/specs/booster_pipeline.spec.ts
+++ b/ee_tests/src/specs/booster_pipeline.spec.ts
@@ -1,7 +1,8 @@
 import { browser, element, by, ExpectedConditions as until, $, $$ } from 'protractor';
-import {WebDriver, error as SE} from 'selenium-webdriver';
+import { WebDriver, error as SE } from 'selenium-webdriver';
 
 import * as support from './support';
+import { Quickstart } from './support/quickstart';
 import { TextInput, Button } from './ui';
 
 import { LandingPage } from './page_objects/landing.page';
@@ -17,13 +18,13 @@ let globalSpacePipelinePage: SpacePipelinePage;
 describe('Creating new quickstart in OSIO', () => {
   let dashboardPage: MainDashboardPage;
 
-  beforeEach( async () => {
+  beforeEach(async () => {
     await support.desktopTestSetup();
     let login = new support.LoginInteraction();
     dashboardPage = await login.run();
   });
 
-  afterEach( async () => {
+  afterEach(async () => {
     await browser.sleep(support.DEFAULT_WAIT);
     await support.dumpLog2(globalSpacePipelinePage, globalSpaceName);
     support.writeScreenshot('target/screenshots/pipeline_final_' + globalSpaceName + '.png');
@@ -35,10 +36,8 @@ describe('Creating new quickstart in OSIO', () => {
 
   it('Create a new space, new ' + browser.params.quickstart.name + ' quickstart, run its pipeline', async () => {
 
-    /* Example of quickstart name:
-       browser.params.quickstart.name = 'wfswarm-circuit-breaker'   */
-
-    await support.info ('quickstart name = ' + browser.params.quickstart.name);
+    let quickstart = new Quickstart(browser.params.quickstart.name);
+    await support.info('Quickstart name: ' + quickstart.name);
 
     let spaceName = support.newSpaceName();
     globalSpaceName = spaceName;
@@ -49,7 +48,7 @@ describe('Creating new quickstart in OSIO', () => {
     //  - do an import of the old space
     await wizard.importExistingCode({
       org: 'WildFly Swarm Boosters for openshift.io',
-      repositories: [browser.params.quickstart.name]
+      repositories: [quickstart.id]
     });
     await spaceDashboardPage.open();
 
@@ -97,7 +96,7 @@ describe('Creating new quickstart in OSIO', () => {
     /* If the build log link is not viewable - the build failed to start */
     support.debug('Verifying that the build has started - check https://github.com/openshiftio/openshift.io/issues/1194');
     await spacePipelinePage.viewLog.untilClickable(support.LONGEST_WAIT);
-    expect (spacePipelinePage.viewLog.isDisplayed()).toBe(true);
+    expect(spacePipelinePage.viewLog.isDisplayed()).toBe(true);
 
     /* Promote to both stage and run - build has completed - if inputRequired is not present, build has failed */
     support.debug('Verifying that the promote dialog is opened');
@@ -113,13 +112,13 @@ describe('Creating new quickstart in OSIO', () => {
 
     support.writeScreenshot('target/screenshots/pipeline_icons_' + spaceName + '.png');
 
-      // TODO - Error conditions to trap
-      // 1) Jenkins build log - find errors if the test fails
-      // 2) Jenkins pod log - find errors if the test fails
-      // 3) Presence of build errors in UI
-      // 4) Follow the stage and run links */
+    // TODO - Error conditions to trap
+    // 1) Jenkins build log - find errors if the test fails
+    // 2) Jenkins pod log - find errors if the test fails
+    // 3) Presence of build errors in UI
+    // 4) Follow the stage and run links */
   });
 
-// tslint:enable:max-line-length
+  // tslint:enable:max-line-length
 
 });

--- a/ee_tests/src/specs/quickstart_analytic.spec.ts
+++ b/ee_tests/src/specs/quickstart_analytic.spec.ts
@@ -1,5 +1,6 @@
 import { browser, element, by, ExpectedConditions as until, $, $$ } from 'protractor';
 import * as support from './support';
+import { Quickstart } from './support/quickstart';
 import { TextInput, Button } from './ui';
 
 import { LandingPage } from './page_objects/landing.page';
@@ -32,70 +33,15 @@ describe('Creating new quickstart in OSIO', () => {
   /* Simple test - accept all defaults for new quickstarts */
 
   it('Create a new space, new ' + browser.params.quickstart.name + ' quickstart, run its pipeline', async () => {
-
-    const getDependencyCountObj = (total: string, analyzed: string, unknown: string) => {
-      return {
-        'total': total,
-        'analyzed': analyzed,
-        'unknown': unknown
-      };
-    };
-
-    let quickstartName, dependencyCountObj;
-
-    switch (browser.params.quickstart.name) {
-      case 'vertxHttp': {
-        quickstartName = 'Vert.x HTTP Booster';
-        dependencyCountObj = getDependencyCountObj('2', '2', '0');
-        break;
-      }
-      case 'vertxConfig': {
-        quickstartName = 'Vert.x - HTTP & Config Map';
-        dependencyCountObj = getDependencyCountObj('9', '9', '0');
-        break;
-      }
-      case 'vertxHealth': {
-        quickstartName = 'Vert.x Health Check Example';
-        dependencyCountObj = getDependencyCountObj('4', '4', '0');
-        break;
-      }
-      case 'SpringBootHttp': {
-        quickstartName = 'Spring Boot - HTTP';
-        dependencyCountObj = getDependencyCountObj('4', '4', '0');
-        break;
-      }
-      case 'SpringBootCrud': {
-        quickstartName = 'Spring Boot - CRUD';
-        dependencyCountObj = getDependencyCountObj('4', '4', '0');
-        break;
-      }
-      case 'SpringBootHealth': {
-        quickstartName = 'Spring Boot Health Check Example';
-        dependencyCountObj = getDependencyCountObj('3', '3', '0');
-        break;
-      }
-      default: {
-        quickstartName = 'Vert.x HTTP Booster';
-        dependencyCountObj = getDependencyCountObj('2', '2', '0');
-        break;
-      }
-    }
-
-    await runTest(dashboardPage, quickstartName, dependencyCountObj);
-  });
-
-  async function runTest(theLandingPage: MainDashboardPage, quickstartName: string, dependencyCountObj: any) {
-
-    await support.info('Quickstart name: ' + quickstartName);
-
+    let quickstart = new Quickstart(browser.params.quickstart.name);
     let spaceName = support.newSpaceName();
     globalSpaceName = spaceName;
     let spaceDashboardPage = await dashboardPage.createNewSpace(spaceName);
 
     let wizard = await spaceDashboardPage.addToSpace();
 
-    support.info('Creating quickstart: ' + quickstartName);
-    await wizard.newQuickstartProject({ project: quickstartName });
+    support.info('Creating quickstart: ' + quickstart.name);
+    await wizard.newQuickstartProject({ project: quickstart.name });
     await spaceDashboardPage.ready();
 
     /* This statement does not reliably wait for the modal dialog to disappear:
@@ -171,9 +117,12 @@ describe('Creating new quickstart in OSIO', () => {
 
     await browser.sleep(support.DEFAULT_WAIT);
     try {
-      await expect(spaceDashboardPage.stackReportDependencyCardTotalCount.getText()).toContain(dependencyCountObj['total']);
-      await expect(spaceDashboardPage.stackReportDependencyCardAnalyzedCount.getText()).toContain(dependencyCountObj['analyzed']);
-      await expect(spaceDashboardPage.stackReportDependencyCardUnknownCount.getText()).toContain(dependencyCountObj['unknown']);
+      await expect(spaceDashboardPage.stackReportDependencyCardTotalCount.getText())
+        .toContain(quickstart.dependencyCount.total);
+      await expect(spaceDashboardPage.stackReportDependencyCardAnalyzedCount.getText())
+        .toContain(quickstart.dependencyCount.analyzed);
+      await expect(spaceDashboardPage.stackReportDependencyCardUnknownCount.getText())
+        .toContain(quickstart.dependencyCount.unknown);
       support.writeScreenshot('target/screenshots/analytic_report_success_' + spaceName + '.png');
     } catch (e) {
       support.writeScreenshot('target/screenshots/analytic_report_fail_' + spaceName + '.png');
@@ -181,6 +130,6 @@ describe('Creating new quickstart in OSIO', () => {
     }
 
     await spaceDashboardPage.analyticsCloseButton.clickWhenReady();
-  }
+  });
 
 });

--- a/ee_tests/src/specs/quickstart_che.spec.ts
+++ b/ee_tests/src/specs/quickstart_che.spec.ts
@@ -1,5 +1,6 @@
 import { browser, ExpectedConditions as until, $, $$ } from 'protractor';
 import * as support from './support';
+import { Quickstart } from './support/quickstart';
 import { TextInput, Button } from './ui';
 
 import { LandingPage } from './page_objects/landing.page';
@@ -49,54 +50,15 @@ describe('Creating new quickstart in OSIO', () => {
   /* Simple test - accept all defaults for new quickstarts */
 
   it('Create a new space, new ' + browser.params.quickstart.name + ' quickstart, run its pipeline', async () => {
-
-    let quickstartName: string;
-
-    switch (browser.params.quickstart.name) {
-      case 'vertxHttp': {
-        quickstartName = 'Vert.x HTTP Booster';
-        break;
-      }
-      case 'vertxConfig': {
-        quickstartName = 'Vert.x - HTTP & Config Map';
-        break;
-      }
-      case 'vertxHealth': {
-        quickstartName = 'Vert.x Health Check Example';
-        break;
-      }
-      case 'SpringBootHttp': {
-        quickstartName = 'Spring Boot - HTTP';
-        break;
-      }
-      case 'SpringBootCrud': {
-        quickstartName = 'Spring Boot - CRUD';
-        break;
-      }
-      case 'SpringBootHealth': {
-        quickstartName = 'Spring Boot Health Check Example';
-        break;
-      }
-      default: {
-        quickstartName = 'Vert.x HTTP Booster';
-        break;
-      }
-    }
-    await runTest(dashboardPage, quickstartName);
-  });
-
-  async function runTest(theLandingPage: MainDashboardPage, quickstartName: string) {
-
-    await support.info('Quickstart name: ' + quickstartName);
-
+    let quickstart = new Quickstart(browser.params.quickstart.name);
     let spaceName = support.newSpaceName();
     globalSpaceName = spaceName;
     let spaceDashboardPage = await dashboardPage.createNewSpace(spaceName);
 
     let wizard = await spaceDashboardPage.addToSpace();
 
-    support.info('Creating quickstart: ' + quickstartName);
-    await wizard.newQuickstartProject({ project: quickstartName });
+    support.info('Creating quickstart: ' + quickstart.name);
+    await wizard.newQuickstartProject({ project: quickstart.name });
     await spaceDashboardPage.ready();
 
     /* This statement does not reliably wait for the modal dialog to disappear:
@@ -154,6 +116,6 @@ describe('Creating new quickstart in OSIO', () => {
 
     /* Switch back to the OSIO browser window */
     await browser.switchTo().window(handles[0]);
-  }
+  });
 
 });

--- a/ee_tests/src/specs/quickstart_deployments.spec.ts
+++ b/ee_tests/src/specs/quickstart_deployments.spec.ts
@@ -2,6 +2,7 @@ import { browser, element, by, ExpectedConditions as until, $, $$ } from 'protra
 import { WebDriver, error as SE } from 'selenium-webdriver';
 
 import * as support from './support';
+import { Quickstart } from './support/quickstart';
 import { TextInput, Button } from './ui';
 
 import { LandingPage } from './page_objects/landing.page';
@@ -34,39 +35,7 @@ describe('Creating new quickstart in OSIO', () => {
   });
 
   it('Create a new space, new ' + browser.params.quickstart.name + ' quickstart, run its pipeline', async () => {
-
-    let quickstartName: string;
-
-    switch (browser.params.quickstart.name) {
-      case 'vertxHttp': {
-        quickstartName = 'Vert.x HTTP Booster';
-        break;
-      }
-      case 'vertxHealth': {
-        quickstartName = 'Vert.x Health Check Example';
-        break;
-      }
-      case 'SpringBootHttp': {
-        quickstartName = 'Spring Boot - HTTP';
-        break;
-      }
-      case 'SpringBootHealth': {
-        quickstartName = 'Spring Boot Health Check Example';
-        break;
-      }
-      default: {
-        quickstartName = 'Vert.x HTTP Booster';
-        break;
-      }
-    }
-    await runTest(dashboardPage, quickstartName);
-  });
-
-  /* Create the quickstart, verify deployment to stage and run */
-  async function runTest(theLandingPage: MainDashboardPage, quickstartName: string) {
-
-    await support.info('Quickstart name: ' + quickstartName);
-
+    let quickstart = new Quickstart(browser.params.quickstart.name);
     let spaceName = support.newSpaceName();
     globalSpaceName = spaceName;
     let spaceDashboardPage = await dashboardPage.createNewSpace(spaceName);
@@ -76,8 +45,8 @@ describe('Creating new quickstart in OSIO', () => {
     //    let strategy: string  = 'releaseStageApproveAndPromote';
     let strategy: string = browser.params.release.strategy;   //'release';
 
-    support.info('Creating quickstart: ' + quickstartName);
-    await wizard.newQuickstartProject({ project: quickstartName, strategy });
+    support.info('Creating quickstart: ' + quickstart.name);
+    await wizard.newQuickstartProject({ project: quickstart.name, strategy });
     await spaceDashboardPage.ready();
 
     /* This statement does not reliably wait for the modal dialog to disappear:
@@ -155,10 +124,6 @@ describe('Creating new quickstart in OSIO', () => {
     // 3) Presence of build errors in UI
     // 4) Follow the stage and run links */
 
-
-
-
-
     const STAGE = 1;
     const RUN = 2;
 
@@ -184,7 +149,6 @@ describe('Creating new quickstart in OSIO', () => {
     textStr = await spaceDeploymentsPage.resourceUsageCardByIndex(1).getText();
     support.info('4 Output from run = ' + textStr);
 
-
     support.writeScreenshot('target/screenshots/pipeline_deployments_' + spaceName + '.png');
     await browser.sleep(60000);
 
@@ -194,6 +158,6 @@ describe('Creating new quickstart in OSIO', () => {
     If the page is fully displayed, verify the page contents, run the app, verify the results
     */
 
-  }
+  });
 
 });

--- a/ee_tests/src/specs/quickstart_pipeline.spec.ts
+++ b/ee_tests/src/specs/quickstart_pipeline.spec.ts
@@ -2,6 +2,7 @@ import { browser, element, by, ExpectedConditions as until, $, $$ } from 'protra
 import { WebDriver, error as SE } from 'selenium-webdriver';
 
 import * as support from './support';
+import { Quickstart } from './support/quickstart';
 import { TextInput, Button } from './ui';
 
 import { LandingPage } from './page_objects/landing.page';
@@ -34,45 +35,7 @@ describe('Creating new quickstart in OSIO', () => {
   });
 
   it('Create a new space, new ' + browser.params.quickstart.name + ' quickstart, run its pipeline', async () => {
-    let quickstartName: string;
-
-    switch (browser.params.quickstart.name) {
-      case 'vertxHttp': {
-        quickstartName = 'Vert.x HTTP Booster';
-        break;
-      }
-      case 'vertxHealth': {
-        quickstartName = 'Vert.x Health Check Example';
-        break;
-      }
-      case 'SpringBootHttp': {
-        quickstartName = 'Spring Boot - HTTP';
-        break;
-      }
-      case 'SpringBootHealth': {
-        quickstartName = 'Spring Boot Health Check Example';
-        break;
-      }
-      case 'SwarmHttp': {
-        quickstartName = 'WildFly Swarm - HTTP';
-        break;
-      }
-      case 'SwarmHealth': {
-        quickstartName = 'WildFly Swarm - Health Checks';
-        break;
-      }
-      default: {
-        quickstartName = 'Vert.x HTTP Booster';
-        break;
-      }
-    }
-    await runTest(dashboardPage, quickstartName);
-  });
-
-  /* Create the quickstart, verify deployment to stage and run */
-  async function runTest(theLandingPage: MainDashboardPage, quickstartName: string) {
-    await support.info('Quickstart name: ' + quickstartName);
-
+    let quickstart = new Quickstart(browser.params.quickstart.name);
     let spaceName = support.newSpaceName();
     globalSpaceName = spaceName;
     let spaceDashboardPage = await dashboardPage.createNewSpace(spaceName);
@@ -82,8 +45,8 @@ describe('Creating new quickstart in OSIO', () => {
     //    let strategy: string  = 'releaseStageApproveAndPromote';
     let strategy: string = browser.params.release.strategy;   //'release';
 
-    support.info('Creating quickstart: ' + quickstartName);
-    await wizard.newQuickstartProject({ project: quickstartName, strategy });
+    support.info('Creating quickstart: ' + quickstart.name);
+    await wizard.newQuickstartProject({ project: quickstart.name, strategy });
     await spaceDashboardPage.ready();
 
     /* This statement does not reliably wait for the modal dialog to disappear:
@@ -168,6 +131,6 @@ describe('Creating new quickstart in OSIO', () => {
     If the page is fully displayed, verify the page contents, run the app, verify the results
     */
 
-  }
+  });
 
 });

--- a/ee_tests/src/specs/support/quickstart.ts
+++ b/ee_tests/src/specs/support/quickstart.ts
@@ -1,0 +1,61 @@
+export class Quickstart {
+  id: string;
+  name: string;
+  dependencyCount: {total: string, analyzed: string, unknown: string};
+
+  constructor(quickstart: string) {
+    this.id = quickstart;
+
+    switch (quickstart) {
+      case 'vertxHealth': {
+        this.name = 'Vert.x Health Check Example';
+        this.dependencyCount = this.getDependencyCountObj('4', '4', '0');
+        break;
+      }
+      case 'vertxConfig': {
+        this.name = 'Vert.x - HTTP & Config Map';
+        this.dependencyCount = this.getDependencyCountObj('9', '9', '0');
+        break;
+      }
+      case 'SpringBootHttp': {
+        this.name = 'Spring Boot - HTTP';
+        this.dependencyCount = this.getDependencyCountObj('4', '4', '0');
+        break;
+      }
+      case 'SpringBootHealth': {
+        this.name = 'Spring Boot Health Check Example';
+        this.dependencyCount = this.getDependencyCountObj('3', '3', '0');
+        break;
+      }
+      case 'SpringBootCrud': {
+        this.name = 'Spring Boot - CRUD';
+        this.dependencyCount = this.getDependencyCountObj('4', '4', '0');
+        break;
+      }
+      case 'SwarmHttp': {
+        this.name = 'WildFly Swarm - HTTP';
+        this.dependencyCount = this.getDependencyCountObj('N/A', 'N/A', 'N/A');
+        break;
+      }
+      case 'SwarmHealth': {
+        this.name = 'WildFly Swarm - Health Checks';
+        this.dependencyCount = this.getDependencyCountObj('N/A', 'N/A', 'N/A');
+        break;
+      }
+      default: {
+        this.id = 'vertxHttp';
+        this.name = 'Vert.x HTTP Booster';
+        this.dependencyCount = this.getDependencyCountObj('2', '2', '0');
+        break;
+      }
+    }
+  }
+
+  private getDependencyCountObj = (total: string, analyzed: string, unknown: string) => {
+    return {
+      'total': total,
+      'analyzed': analyzed,
+      'unknown': unknown
+    };
+  }
+}


### PR DESCRIPTION
Quickstart selection refactored so that now all quickstarts are defined in one place.

tested with these configurations:

    runTest / vertxHttp / releaseStageApproveAndPromote
    quickstartTest / vertxHttp / releaseStageApproveAndPromote
    chequickstartTest / vertxHttp / releaseStageApproveAndPromote
    runTest / vertxHttp / release
    runTest / vertxHealth / releaseStageApproveAndPromote
    runTest / SpringBootHttp / releaseAndStage
    runTest / SpringBootHealth / releaseStageApproveAndPromote
    runTest / SwarmHttp / releaseStageApproveAndPromote
    runTest / SwarmHealth / releaseStageApproveAndPromote