### PR TITLE
fix(test): dump all text from login page to stdout - to aid in debugging

### DIFF
--- a/ee_tests/src/specs/page_objects/login.page.ts
+++ b/ee_tests/src/specs/page_objects/login.page.ts
@@ -48,6 +48,9 @@ export class LoginPage extends BasePage {
 
     this.debug('... Login: input details and click Login - OK');
 
+    let theText = await this.everythingOnPage.getText();
+    support.info ('Text on login page = ' + theText);
+
     let mainDashboard = new MainDashboardPage()
     await mainDashboard.open()
     return mainDashboard;


### PR DESCRIPTION
We are seeing login failures for an automated test that utilizes a user account on the new cluster. The username/password credential has been reset, but the test is still failing. This change dumps all login page text to stdout to enable us to debug the failures. The change intentionally takes ALL the text from the page and not only any error message/alert. The username/password are not printed to stdout.