### PR TITLE
fix(test): poc test for junit tests running in Che

### DIFF
--- a/ee_tests/protractorTS.config.ts
+++ b/ee_tests/protractorTS.config.ts
@@ -48,6 +48,8 @@ let conf: Config = {
 
       boosterterminaltest: ['src/quickstart_cheterminal.spec.js'],
 
+      boosterjunittest: ['src/quickstart_chejunit.spec.js'],
+
       logintest: ['src/quickstart_login.spec.js'],
       boosterTest: ['src/booster_pipeline.spec.js'],
       importTest: ['src/workshop-import-to-space.spec.js'],

--- a/ee_tests/src/page_objects/space_cheworkspace.page.ts
+++ b/ee_tests/src/page_objects/space_cheworkspace.page.ts
@@ -1,15 +1,13 @@
 /*
-  OSIO EE test - Page object model - The page hierarchy is:
-  * landing.page.ts - User starts here - User selects "Log In" and is moved to the login page
-  * login.page.ts - At this page the user selects the log in path, enters name/password
-  * main_dashboard.page.ts - Account dashboard page - This is the user's top level page insisde of OSIO
-  * space_dashboard.page.ts - Space dashboard page - From here the user is able to perform tasks inside the space
+  OSIO EE test - Page object model - Che workspace page
 */
+
 // tslint:disable:max-line-length
-import { browser, element, by, By, ExpectedConditions as until, $, $$, ElementFinder, ElementArrayFinder } from 'protractor';
+import { browser, Key, element, by, By, ExpectedConditions as until, $, $$, ElementFinder, ElementArrayFinder } from 'protractor';
 // tslint:ensable:max-line-length
 import { AppPage } from './app.page';
 import { TextInput, Button } from '../ui';
+import * as support from '../support';
 
 export class SpaceCheWorkspacePage extends AppPage {
 
@@ -49,10 +47,56 @@ export class SpaceCheWorkspacePage extends AppPage {
   bottomPanelTerminalConsoleLines = element.all(by.xpath(".//*[contains(@class,'xterm-rows')]"));
   bottomPanelTerminalConsoleLastLine = element.all(by.xpath(".//*[contains(@class,'xterm-rows')]/div")).last();
 
+  /* Assistent top level menu item, navigate to file subtopic */
+  assistant = new Button (element(by.xpath('.//*[@id=\'gwt-debug-MenuItem\/assistantGroup-true\']')), 'Assistant');
+  navigateToFile = new Button (element(by.xpath('.//*[@id=\'topmenu\/Assistant\/Navigate to File\']')), 'Navigate to file');
+  navigateFileName = new TextInput (element(by.xpath('.//*[@id=\'gwt-debug-navigateToFile-fileName\']')));
+  navigateFilePopupPanel = element(by.xpath('.//*[contains(@class,\'gwt-PopupPanel\')]'));
+
+  /* Che menu - Run, Test, Junit commands */
+  cheMenuRun = new Button (element(by.xpath('.//*[@id=\'gwt-debug-MenuItem\/runGroup-true\']')), 'Run menu');
+  cheMenuRunTest = new Button (element(by.xpath('.//*[@id=\'topmenu\/Run\/Test\']')), 'Run -> Test');
+  cheMenuRunTestJunit = new Button (element(by.xpath('.//*[@id=\'topmenu\/Run\/Test\/Run JUnit Test\']')), 'Run -> Test -> Junit');
+
+  /* Junit output is displayed here */
+  debugInfoPanel = new TextInput (element(by.xpath('.//*[@id=\'gwt-debug-infoPanel\']')));
+
+  /* Project name as displayed in project explorer */
   recentProjectRootByName (projectName: string): ElementFinder {
     let xpathString = './/*[@id=\'gwt-debug-projectTree\']/div[contains(@name,\'' + projectName + '\')]';
     return element(by.xpath(xpathString));
   }
+
+/* Locate folder/file elements in the project tree in Che */
+chePathElement (elementString: string): ElementFinder {
+  let xpathString = '(.//*[contains (@path,\'' + elementString + '\')])[1]';
+  return element(by.xpath(xpathString));
+}
+
+/* And locate the folder expansion icon for folder elements in the project tree in Che */
+chePathElementIcon (elementString: string): Button {
+  let xpathString = './/*[contains (@path,\'' + elementString + '\')]//*[contains(@id,\'Layer_1\')]';
+  return new Button (element(by.xpath(xpathString)), 'Folder tree element');
+}
+
+/* Locate folder/file element in the project tree in Che */
+cheFileName (elementString: string): Button {
+  let xpathString = './/*[contains (@class,\'GDPEHSMCNBB\')]//*[contains(text(),\'' + elementString + '\')]';
+  return new Button (element(by.xpath(xpathString)), 'The filename in Che');
+}
+
+/* Given a set of parameters where each parameter is a folder or class, "walk"
+   (traverse) project tree in Che, expanding each element */
+async walkTree (...theArgs: string[]) {
+  let xpathString: string = '';
+  for (let i = 0; i < theArgs.length; i++) {
+    xpathString += theArgs[i];
+
+    await this.chePathElementIcon(xpathString).clickWhenReady();
+    let theText = await this.chePathElement(xpathString).getText();
+    support.info ('Opened path = ' + theText);
+  }
+}
 
 // tslint:enable:max-line-length
 

--- a/ee_tests/src/quickstart_chejunit.spec.ts
+++ b/ee_tests/src/quickstart_chejunit.spec.ts
@@ -1,0 +1,119 @@
+import { browser, Key, ExpectedConditions as until, $, $$ } from 'protractor';
+import * as support from './support';
+import { Quickstart } from './support/quickstart';
+import { TextInput, Button } from './ui';
+import { LandingPage } from './page_objects/landing.page';
+import { SpaceDashboardPage } from './page_objects/space_dashboard.page';
+import { SpaceChePage } from './page_objects/space_che.page';
+import { SpaceCheWorkspacePage } from './page_objects/space_cheworkspace.page';
+import { MainDashboardPage } from './page_objects/main_dashboard.page';
+
+let globalSpaceName: string;
+
+/* Tests to verify Che in OSIO */
+
+describe('Creating new quickstart in OSIO', () => {
+  let dashboardPage: MainDashboardPage;
+
+  beforeEach(async () => {
+    await support.desktopTestSetup();
+    let login = new support.LoginInteraction();
+    dashboardPage = await login.run();
+
+    let userProfilePage = await dashboardPage.gotoUserProfile();
+    support.debug(">>> Go to user's Profile Page - OK");
+    support.debug('>>> Go to Edit Profile Page');
+    let editProfilePage = await userProfilePage.gotoEditProfile();
+    support.debug('>>> Go to Edit Profile Page - OK');
+    support.debug('>>> Go to Reset Env Page');
+    let cleanupEnvPage = await editProfilePage.gotoResetEnvironment();
+    support.debug('>>> Go to Reset Env Page - OK');
+
+    await cleanupEnvPage.cleanup(browser.params.login.user);
+  });
+
+  afterEach( async () => {
+    support.writeScreenshot('target/screenshots/che_final_' + globalSpaceName + '.png');
+    support.info('\n ============ End of test reached ============ \n');
+    await dashboardPage.logout();
+  });
+
+  /* Accept all defaults for new quickstarts */
+
+    // tslint:disable:max-line-length
+  it('Create a new space, new ' + browser.params.quickstart.name + ' quickstart, create Che workspace, run maven in the workspace', async () => {
+    let quickstart = new Quickstart(browser.params.quickstart.name);
+    let spaceName = support.newSpaceName();
+    globalSpaceName = spaceName;
+    let spaceDashboardPage = await dashboardPage.createNewSpace(spaceName);
+
+    let wizard = await spaceDashboardPage.addToSpace();
+
+    support.info('Creating quickstart: ' + quickstart.name);
+    await wizard.newQuickstartProject({ project: quickstart.name });
+    await spaceDashboardPage.ready();
+
+    /* Open Che display page */
+    await spaceDashboardPage.codebasesSectionTitle.clickWhenReady();
+
+    let spaceChePage = new SpaceChePage();
+    await spaceChePage.createCodebase.clickWhenReady(support.LONGEST_WAIT);
+
+    /* A new browser window is opened when Che opens - switch to that new window now */
+    let handles = await browser.getAllWindowHandles();
+    support.debug('Number of browser tabs before = ' + handles.length);
+    await browser.wait(windowCount(2), support.DEFAULT_WAIT);
+    handles = await browser.getAllWindowHandles();
+    support.debug('Number of browser tabs after = ' + handles.length);
+    support.writeScreenshot('target/screenshots/che_workspace_parta_' + spaceName + '.png');
+
+    /* Switch to the Che browser window */
+    await browser.switchTo().window(handles[1]);
+    let spaceCheWorkSpacePage = new SpaceCheWorkspacePage();
+    support.writeScreenshot('target/screenshots/che_workspace_partb_' + spaceName + '.png');
+
+    /* Find the project */
+    let projectInCheTree = new Button(spaceCheWorkSpacePage.recentProjectRootByName(spaceName), 'Project in Che Tree');
+    await projectInCheTree.untilPresent(support.LONGEST_WAIT);
+    support.writeScreenshot('target/screenshots/che_workspace_partc_' + spaceName + '.png');
+    expect(await spaceCheWorkSpacePage.recentProjectRootByName(spaceName).getText()).toContain(spaceName);
+
+    /* Open the terminal window and execute maven install command */
+    await spaceCheWorkSpacePage.bottomPanelTerminalTab.clickWhenReady();
+    await support.printTerminal(spaceCheWorkSpacePage, 'cd ' + spaceName);
+    await support.printTerminal(spaceCheWorkSpacePage, 'mvn clean install');
+    await browser.wait(until.textToBePresentInElement(spaceCheWorkSpacePage.bottomPanelTerminal, 'BUILD SUCCESS'), support.LONGER_WAIT);
+    await expect(spaceCheWorkSpacePage.bottomPanelTerminal.getText()).toContain('BUILD SUCCESS');
+    await expect(spaceCheWorkSpacePage.bottomPanelTerminal.getText()).not.toContain('BUILD FAILURE');
+
+    /* Run the Junit tests */
+    await spaceCheWorkSpacePage.walkTree(spaceName, '\/src', '\/test', '\/java', '\/io', '\/openshift', '\/booster');
+    await browser.wait(until.visibilityOf(spaceCheWorkSpacePage.cheFileName('HttpApplicationTest.java')), support.DEFAULT_WAIT);
+
+    let theText = await spaceCheWorkSpacePage.cheFileName('HttpApplicationTest.java').getText();
+    support.info ('filename = ' + theText);
+    await spaceCheWorkSpacePage.cheFileName('HttpApplicationTest.java').clickWhenReady();
+
+    // Run the junit test
+    spaceCheWorkSpacePage.cheMenuRun.clickWhenReady();
+    spaceCheWorkSpacePage.cheMenuRunTest.clickWhenReady();
+    spaceCheWorkSpacePage.cheMenuRunTestJunit.clickWhenReady();
+
+    await browser.wait(until.textToBePresentInElement(spaceCheWorkSpacePage.debugInfoPanel, 'Total tests run: 2, Failures: 0, Skips: 0'), support.LONGER_WAIT);
+    await expect(spaceCheWorkSpacePage.debugInfoPanel.getText()).toContain('Failures: 0');
+    await expect(spaceCheWorkSpacePage.debugInfoPanel.getText()).toContain('Skips: 0');
+    await expect(spaceCheWorkSpacePage.debugInfoPanel.getText()).not.toContain('Total tests run: 0');
+
+    /* Switch back to the OSIO browser window */
+    await browser.switchTo().window(handles[0]);
+  });
+
+  function windowCount (count: number) {
+    return function () {
+        return browser.getAllWindowHandles().then(function (handles) {
+            return handles.length === count;
+        });
+    };
+  }
+
+});

--- a/ee_tests/src/support/core.ts
+++ b/ee_tests/src/support/core.ts
@@ -34,7 +34,6 @@ export async function setBrowserMode(mode: BrowserMode) {
   }
 }
 
-
 /* Print text to the Che Terminal window - a 2nd RETURN char is used to make the text easier to read */
 // tslint:disable:max-line-length
 export async function printTerminal (spaceCheWorkspacePage: SpaceCheWorkspacePage, textToPrint: string) {
@@ -44,7 +43,6 @@ export async function printTerminal (spaceCheWorkspacePage: SpaceCheWorkspacePag
   await browser.driver.actions().mouseDown(spaceCheWorkspacePage.bottomPanelTerminal).click().sendKeys(Key.ENTER).perform();
 }
 // tslint:enable:max-line-length
-
 
 /*
  * Display the contents of the Jenkins build log.


### PR DESCRIPTION
This is a sample test, illustrating running a maven build in the Che terminal window, and then running Junit tests in Che. We will likely refactor this test into a booster test by extracting much of the test setup into separate tests in a test suite.