### PR TITLE
fix(test): correct error in analytics report values

### DIFF
--- a/ee_tests/src/support/quickstart.ts
+++ b/ee_tests/src/support/quickstart.ts
@@ -45,7 +45,7 @@ export class Quickstart {
       default: {
         this.id = 'vertxHttp';
         this.name = 'Vert.x HTTP Booster';
-        this.dependencyCount = this.getDependencyCountObj('2', '0', '2');
+        this.dependencyCount = this.getDependencyCountObj('2', '2', '0');
         break;
       }
     }


### PR DESCRIPTION
This fix will enable the E2E test running on Centos Ci to pass. The other tests will be addressed in other pull requests.