### PR TITLE
Added protractor-fail-fast

### DIFF
--- a/ee_tests/.gitignore
+++ b/ee_tests/.gitignore
@@ -7,3 +7,4 @@ protractorTS.config.js.map
 index.js
 index.js.map
 .vscode/
+.protractor-fail-fast

--- a/ee_tests/declarations.d.ts
+++ b/ee_tests/declarations.d.ts
@@ -2,3 +2,4 @@ declare module "HtmlScreenshotReporter";
 declare module "protractor-jasmine2-screenshot-reporter";
 declare module "jasmine-spec-reporter";
 declare module "jasmine-protractor-matchers";
+declare module 'protractor-fail-fast';

--- a/ee_tests/package-lock.json
+++ b/ee_tests/package-lock.json
@@ -656,6 +656,23 @@
       "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
       "dev": true
     },
+    "jasmine-fail-fast": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-fail-fast/-/jasmine-fail-fast-2.0.0.tgz",
+      "integrity": "sha1-5dguaimiX2YsZA5MMnDC+acTh+c=",
+      "dev": true,
+      "requires": {
+        "lodash": "3.10.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz",
+          "integrity": "sha1-k9UcZygopEFqEq9XIguoqHN+L7s=",
+          "dev": true
+        }
+      }
+    },
     "jasmine-protractor-matchers": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jasmine-protractor-matchers/-/jasmine-protractor-matchers-2.0.0.tgz",
@@ -989,6 +1006,15 @@
             "xml2js": "0.4.19"
           }
         }
+      }
+    },
+    "protractor-fail-fast": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/protractor-fail-fast/-/protractor-fail-fast-3.1.0.tgz",
+      "integrity": "sha512-OjuIFmY7hm5R/Msmioyg3aBevySpmpIgtm2TGUvMEqTzviPk/Fqd1HYmMjIQ+NzFMzrK+93LJa4civDvw1+hEg==",
+      "dev": true,
+      "requires": {
+        "jasmine-fail-fast": "2.0.0"
       }
     },
     "protractor-jasmine2-screenshot-reporter": {

--- a/ee_tests/package.json
+++ b/ee_tests/package.json
@@ -45,6 +45,7 @@
     "jasmine-protractor-matchers": "^2.0.0",
     "jasmine-spec-reporter": "^4.2.1",
     "protractor": "^5.3.0",
+    "protractor-fail-fast": "^3.1.0",
     "protractor-jasmine2-screenshot-reporter": "^0.5.0",
     "tslint": "^5.9.1",
     "tslint-loader": "^3.5.0",

--- a/ee_tests/protractorTS.config.ts
+++ b/ee_tests/protractorTS.config.ts
@@ -1,5 +1,6 @@
 import { Config, browser } from 'protractor';
 import { SpecReporter } from 'jasmine-spec-reporter';
+import * as failFast from 'protractor-fail-fast';
 
 // NOTE: weird import as documented in
 // https://github.com/Xotabu4/jasmine-protractor-matchers
@@ -17,7 +18,7 @@ let reporter = new HtmlScreenshotReporter({
 // Full protractor configuration file reference could be found here:
 // https://github.com/angular/protractor/blob/master/lib/config.ts
 let conf: Config = {
-
+  
     framework: 'jasmine2',
 
     jasmineNodeOpts: {
@@ -26,6 +27,10 @@ let conf: Config = {
       isVerbose: true,
       defaultTimeoutInterval: 60 * 60 * 1000 // 60 mins for spec to run
     },
+
+    plugins: [
+      failFast.init()
+    ],
 
     directConnect: process.env.DIRECT_CONNECTION === 'true',
     restartBrowserBetweenTests: true,


### PR DESCRIPTION
Added protractor-fail-fast dependency that allows to exit tests  on the first failure
instead of running all tests.