### PR TITLE
fix(test): The reports fields shifted - causing test failures

### DIFF
--- a/ee_tests/src/support/quickstart.ts
+++ b/ee_tests/src/support/quickstart.ts
@@ -66,7 +66,7 @@ export class Quickstart {
         this.name = 'Vert.x HTTP Booster';
         this.runtime = LauncherRuntime.runtime(LauncherRuntime.VERTX);
         this.mission = LauncherMission.mission(LauncherMission.REST_HTTP);
-        this.dependencyCount = this.getDependencyCountObj('2', '0', '2');
+        this.dependencyCount = this.getDependencyCountObj('2', '2', '0');
         break;
       }
     }


### PR DESCRIPTION
This is an odd one - as the order was also changed a couple of weeks ago. Will investigate with the analytics team.