### PR TITLE
fix(test): add browser wait statements to ensure that UI elements are present

### DIFF
--- a/ee_tests/src/page_objects/space_deployments.page.ts
+++ b/ee_tests/src/page_objects/space_deployments.page.ts
@@ -15,8 +15,16 @@ import { SpaceHeader } from './app/spaceHeader';
 
 export class SpaceDeploymentsPage extends AppPage {
 
+  deploymentCardContainerFirstElement = element.all(by.xpath('.//deployment-card-container')).first();
+  resourceUsageDataFirstElement = element.all(by.xpath('.//resource-card')).first();
+
   async getDeployedApplications(): Promise<DeployedApplication[]> {
+
+    /* Allow for delays in applications appearing in UI - assume that we always have at least 1 app */
+    await browser.wait(until.visibilityOf(this.deploymentCardContainerFirstElement), support.LONGER_WAIT);
+
     let elementFinders: ElementFinder[] = await element.all(by.tagName('deployment-card-container'));
+    support.info ('Total number of apps found = ' + elementFinders.length);
 
     let applications = new Array<DeployedApplication>();
     for (let finder of elementFinders) {
@@ -26,7 +34,12 @@ export class SpaceDeploymentsPage extends AppPage {
   }
 
   async getResourceUsageData(): Promise<ResourceUsageData[]> {
+
+    /* Allow for delays in applications appearing in UI - assume that we always have at least 1 app */
+    await browser.wait(until.visibilityOf(this.resourceUsageDataFirstElement), support.LONGER_WAIT);
+
     let elementFinders: ElementFinder[] = await element.all(by.tagName('resource-card'));
+    support.info ('Total number of resources found = ' + elementFinders.length);
 
     let data = new Array<ResourceUsageData>();
     for (let finder of elementFinders) {


### PR DESCRIPTION
The smoketest is repeatedly failing on Centos CI - due to the deployments' page applications not being found. In debugging/running this locally, I found that it was happening intermittently. Must be a timing issue. 

```
Creating new quickstart in OSIO Create a new space, new vertxHttp quickstart, run its pipeline
  - Expected 0 to be 1, 'number of deployed applications'.
  - Failed: Cannot read property 'getName' of undefined
```

Adding protractor expected condition (until) to wait until the applications are visible. This passed 10 of 10 attempts running locally. Without this change - the test failed 2 out of 10 times locally.