### PR TITLE
fix(test): added booster tests: preview app, modify src file

### DIFF
--- a/ee_tests/protractorTS.config.ts
+++ b/ee_tests/protractorTS.config.ts
@@ -64,6 +64,7 @@ let conf: Config = {
         'src/booster_ee_int_tests/booster_run_project.spec.js',
         'src/booster_ee_int_tests/booster_debug_project.spec.js',
         'src/booster_ee_int_tests/booster_junit_tests.spec.js',
+        'src/booster_ee_int_tests/booster_che_preview.spec.js',
         'src/booster_ee_int_tests/booster_modify_src.spec.js',
         'src/booster_ee_int_tests/booster_cleanup.spec.js'
       ],

--- a/ee_tests/src/booster_ee_int_tests/booster_che_preview.spec.ts
+++ b/ee_tests/src/booster_ee_int_tests/booster_che_preview.spec.ts
@@ -20,18 +20,18 @@ let globalSpacePipelinePage: SpacePipelinePage;
 const SRCFILENAME: string = 'HttpApplication.java';
 
 /* Text used to verify operation of deployed app, before and after the app is modified */
-const EXPECTED_TEXT_AFTER_SEND = 'Howdee, World';
-const EXPECTED_TEXT_AFTER_RECEIVED = 'Howdee, Howdee, World!';
-const EXPECTED_SUCCESS_TEXT = 'Succeeded in deploying verticle';  // TODO - Need unique string for each booster
+const EXPECTED_TEXT_SEND = 'World';
+const EXPECTED_TEXT_RECEIVED = 'Hello, World!';
+const EXPECTED_SUCCESS_TEXT = (
+  new Quickstart(browser.params.quickstart.name)
+).runtime.quickstartStartedTerminal;
 
 // tslint:disable:max-line-length
 
 /* This test performs these steps:
-   - Execute the quickstart/booster through the Che run menu, verify output from the deployed app
-   - Update the source of the quickstart/booster
-   - Execute the quickstart/booster through the Che run menu, verify output from the deployed app   */
+   - Execute the quickstart/booster through the Che run menu, verify output from the deployed app  */
 
-describe('Modify the project source code in Che:', () => {
+describe('Verify the Che preview URL for a deployed app:', () => {
   let dashboardPage: MainDashboardPage;
 
   beforeEach(async () => {
@@ -45,10 +45,10 @@ describe('Modify the project source code in Che:', () => {
     await dashboardPage.logout();
   });
 
-  it('Login, edit code in Che, logout', async () => {
-    support.info('Che edit test starting now...');
+  it('Login, run in Che, verify URL, logout', async () => {
+    support.info('Che preview URL test starting now...');
 
-    /* Part 1 - Run the app, verify the deployed app performs as expected */
+    /* Run the app, verify the deployed app performs as expected */
 
     /* Open the codebase page and the workspace in Che */
     await support.openCodebasesPage (browser.params.target.url, browser.params.login.user, support.currentSpaceName());
@@ -71,56 +71,12 @@ describe('Modify the project source code in Che:', () => {
     await projectInCheTree.untilPresent(support.LONGEST_WAIT);
     support.writeScreenshot('target/screenshots/che_edit_project_tree_' + support.currentSpaceName() + '.png');
 
-    /* Locate the file in the project tree */
-    try {
-      await spaceCheWorkSpacePage.walkTree(support.currentSpaceName(), '\/src', '\/main', '\/java', '\/io', '\/openshift', '\/booster');
-      await browser.wait(until.visibilityOf(spaceCheWorkSpacePage.cheFileName(SRCFILENAME)), support.DEFAULT_WAIT);
-    } catch (e) {
-      support.info('Exception in Che project directory tree = ' + e);
-  }
-
-    /* Modify the deployed app source code */
-    let theText = await spaceCheWorkSpacePage.cheFileName(SRCFILENAME).getText();
-    support.info ('filename = ' + theText);
-    await spaceCheWorkSpacePage.cheFileName(SRCFILENAME).clickWhenReady();
-
-    /* Right click on file name */
-    await browser.actions().click(spaceCheWorkSpacePage.cheFileName(SRCFILENAME), protractor.Button.RIGHT).perform();
-
-    /* Open the file edit menu */
-    await spaceCheWorkSpacePage.cheContextMenuEditFile.clickWhenReady();
-
-    /* Disable param and braces - to avoid introducing extra characters */
-    await support.changePreferences(spaceCheWorkSpacePage, 'disable');
-
-    /* Replace the file contents */
-    try {
-      await spaceCheWorkSpacePage.cheText.clickWhenReady(support.LONG_WAIT);
-      await spaceCheWorkSpacePage.cheText.sendKeys('text was', Key.CONTROL, 'a', Key.NULL, support.FILETEXT);
-      await spaceCheWorkSpacePage.cheMenuEdit.clickWhenReady(support.LONG_WAIT);
-      await spaceCheWorkSpacePage.cheEditFormat.clickWhenReady(support.LONG_WAIT);
-    } catch (e) {
-     support.info('Exception in writing to file in Che = ' + e);
-    }
-
-    /* Re-enable preferences */
-    await support.changePreferences(spaceCheWorkSpacePage, 'enable');
-    support.writeScreenshot('target/screenshots/che_workspace_part_edit_' + support.currentSpaceName() + '.png');
-
-    /* Close the editor window and select the project in the project tree */
-    await browser.switchTo().window(handles[1]);
-    await projectInCheTree.untilPresent(support.LONGEST_WAIT);
-    projectInCheTree.clickWhenReady();
-
-    /* Part 3 - Run the app, verify the deployed app performs as expected */
-
-    /* Run the project - verify the output from the deployed (in Che preview) service endpoint */
     /* Run the project - verify the output from the deployed (in Che preview) serviceendpoint */
     await support.runBooster(spaceCheWorkSpacePage, EXPECTED_SUCCESS_TEXT);
 
     /* Invoke the deployed app at its endpoint, verify the app's output */
     let boosterEndpointPage = new BoosterEndpoint();
-    await support. invokeApp (boosterEndpointPage, spaceCheWorkSpacePage, browser.params.oso.username, 'post_edit', EXPECTED_TEXT_AFTER_SEND, EXPECTED_TEXT_AFTER_RECEIVED, spaceCheWorkSpacePage);
+    await support.invokeApp (boosterEndpointPage, spaceCheWorkSpacePage, browser.params.oso.username, 'pre_edit', EXPECTED_TEXT_SEND, EXPECTED_TEXT_RECEIVED, spaceCheWorkSpacePage);
 
     /* Close the Endpoint window */
     await browser.close();

--- a/ee_tests/src/booster_ee_int_tests/quickstart_che_editor.spec.ts
+++ b/ee_tests/src/booster_ee_int_tests/quickstart_che_editor.spec.ts
@@ -210,13 +210,13 @@ describe('Creating new Che workspace and edit in OSIO', () => {
       let autoParanEnabled: boolean = await spaceCheWorkSpacePage.chePreferencesAutopairParen.isSelected();
       if (autoParanEnabled) {
         support.info('Disabling enabled auto pair paren');
-        await spaceCheWorkSpacePage.chePreferencesAutopairParenParent.clickWhenReady();
+        await spaceCheWorkSpacePage.chePreferencesAutopairParen.clickWhenReady();
         await spaceCheWorkSpacePage.chePreferencesStoreChanges.clickWhenReady();
       }
       let autoBracesEnabled: boolean = await spaceCheWorkSpacePage.chePreferencesAutoBraces.isSelected();
       if (autoBracesEnabled) {
         support.info('Disabling enabled auto braces');
-        await spaceCheWorkSpacePage.chePreferencesAutoBracesParent.clickWhenReady();
+        await spaceCheWorkSpacePage.chePreferencesAutoBraces.clickWhenReady();
         await spaceCheWorkSpacePage.chePreferencesStoreChanges.clickWhenReady();
       }
     }
@@ -225,13 +225,13 @@ describe('Creating new Che workspace and edit in OSIO', () => {
         let autoParanEnabled: boolean = await spaceCheWorkSpacePage.chePreferencesAutopairParen.isSelected();
         if (!autoParanEnabled) {
           support.info('Enabling disabled auto pair paren');
-          await spaceCheWorkSpacePage.chePreferencesAutopairParenParent.clickWhenReady();
+          await spaceCheWorkSpacePage.chePreferencesAutopairParen.clickWhenReady();
           await spaceCheWorkSpacePage.chePreferencesStoreChanges.clickWhenReady();
         }
         let autoBracesEnabled: boolean = await spaceCheWorkSpacePage.chePreferencesAutoBraces.isSelected();
         if (!autoBracesEnabled) {
           support.info('Enabling disabled auto braces');
-          await spaceCheWorkSpacePage.chePreferencesAutoBracesParent.clickWhenReady();
+          await spaceCheWorkSpacePage.chePreferencesAutoBraces.clickWhenReady();
           await spaceCheWorkSpacePage.chePreferencesStoreChanges.clickWhenReady();
         }
       }

--- a/ee_tests/src/page_objects/booster_endpoint.page.ts
+++ b/ee_tests/src/page_objects/booster_endpoint.page.ts
@@ -1,0 +1,21 @@
+/*
+  OSIO EE test - Page object model - Deployed Booster app
+*/
+
+// tslint:disable:max-line-length
+import { browser, Key, element, by, By, ExpectedConditions as until, $, $$, ElementFinder, ElementArrayFinder } from 'protractor';
+// tslint:ensable:max-line-length
+import { AppPage } from './app.page';
+import { TextInput, Button } from '../ui';
+
+export class BoosterEndpoint extends AppPage {
+
+  // tslint:disable:max-line-length
+
+  nameText = new TextInput(element(by.xpath('.//input[contains(@id, \'name\')]')) , 'Name text field');
+  invokeButton = new Button($('#invoke'), 'Invoke Button');
+  stageOutput = element(by.id('greeting-result'));
+
+// tslint:enable:max-line-length
+
+}

--- a/ee_tests/src/page_objects/space_che.page.ts
+++ b/ee_tests/src/page_objects/space_che.page.ts
@@ -18,7 +18,8 @@ export class SpaceChePage extends AppPage {
 
   /* 'Open' button for existing codebase */
   codebaseOpenButton (githubUsername: string, spaceName: string): ElementFinder {
-    let xpathString = './/codebases-item//*[contains(@class,\'list-pf-title\')]//*[contains(text(),\'' + githubUsername + '\/' + spaceName + '\')]/../../..//button[contains(text(),\'Open\')]';
+  //  let xpathString = './/codebases-item//*[contains(@class,\'list-pf-title\')]//*[contains(text(),\'' + githubUsername + '\/' + spaceName + '\')]/../../..//button[contains(text(),\'Open\')]';
+    let xpathString = './/button[contains(text(),\'Open\')]';
     return new Button (element (by.xpath(xpathString)), 'Open codebase button');
   }
 

--- a/ee_tests/src/page_objects/space_cheworkspace.page.ts
+++ b/ee_tests/src/page_objects/space_cheworkspace.page.ts
@@ -27,6 +27,8 @@ export class SpaceCheWorkspacePage extends AppPage {
 
   /* Bottom Panel run tab */
   bottomPanelRunTab = new Button (element(by.xpath('.//*[contains(@class,\'GDPEHSMCKHC\')][contains(text(),\'run\')]')), 'Che Bottom Panel Run Tab');
+  bottomPanelRunTabCloseButton = new Button (element(by.xpath('.//*[contains(@class,\'GDPEHSMCKHC\')][contains(text(),\'run\')]/..//*[contains(@class,\'GDPEHSMCGHC\')]')), 'Che Bottom Panel Run Tab close button');
+  bottomPanelRunTabOKButton =  new Button (element(by.xpath('.//button[contains(@id, \'ask-dialog-ok\')]')), 'RUn tab OK button');
 
   /* Bottom Panel terminal tab */
   bottomPanelTerminalTab = new Button (element(by.xpath('.//*[contains(@class,\'GDPEHSMCKHC\')][contains(text(),\'Terminal\')]')), 'Che Bottom Panel Terminal Tab');
@@ -54,11 +56,7 @@ export class SpaceCheWorkspacePage extends AppPage {
   navigateToFile = new Button (element(by.xpath('.//*[@id=\'topmenu\/Assistant\/Navigate to File\']')), 'Navigate to file');
   navigateFileName = new TextInput (element(by.xpath('.//*[@id=\'gwt-debug-navigateToFile-fileName\']')));
   navigateFilePopupPanel = element(by.xpath('.//*[contains(@class,\'gwt-PopupPanel\')]'));
-
-
   fileNameTab = new Button (element(by.xpath('.//*[contains(@class=\'GDPEHSMCDDC GDPEHSMCGK\')]')), 'File tab');
-//  <div class="GDPEHSMCDDC GDPEHSMCGK" style="color: rgb(255, 255, 255);">HttpApplicationTest</div>
-
 
   /* Che menu - Run, Test, Junit commands */
   cheMenuRun = new Button (element(by.xpath('.//*[@id=\'gwt-debug-MenuItem\/runGroup-true\']')), 'Run menu');
@@ -74,6 +72,7 @@ export class SpaceCheWorkspacePage extends AppPage {
   /* Che menu edit */
   cheMenuEdit = new Button (element(by.xpath('.//*[@id=\'gwt-debug-MenuItem\/editGroup-true\']')), 'Edit in file');
   cheEditFind = new Button (element(by.xpath('.//*[@id=\'topmenu/Edit/Find\']')), 'Find in edit');
+  cheEditFormat = new Button (element(by.xpath('.//*[@id=\'topmenu/Edit/Format\']')), 'Format file');
 
   /* Che find and replace */
   cheFindTextToReplace = new TextInput (element(by.xpath('.//input[@class=\'textViewFindInput\']')), 'Che text to find');
@@ -89,12 +88,16 @@ export class SpaceCheWorkspacePage extends AppPage {
   cheProfileGroup = new Button (element(by.xpath('.//*[@id=\'gwt-debug-MenuItem\/profileGroup-true\']')), 'Profile group button');
   chePreferences = new Button (element(by.xpath('.//*[@id=\'topmenu\/Profile\/Preferences\']')), 'Preferences button');
   chePreferencesEditor = new Button (element(by.xpath('.//*[@id=\'gwt-debug-projectWizard-Editor\']')), 'Preferences Editor button');
-  chePreferencesAutopairParen = new Button (element(by.xpath('.//*[@id=\'gwt-uid-157\']')), 'Preferences Auto Paren');
-  chePreferencesAutoBraces = new Button (element(by.xpath('.//*[@id=\'gwt-uid-156\']')), 'Preferences Auto Braces');
-  chePreferencesAutopairParenParent = new Button (element(by.xpath('.//*[@id=\'gwt-uid-167\']\/..')), 'Preferences Auto Paren');
-  chePreferencesAutoBracesParent = new Button (element(by.xpath('.//*[@id=\'gwt-uid-166\']\/..')), 'Preferences Auto Braces');
+  chePreferencesAutopairParen = new Button (element(by.xpath('(.//*[contains (@class,\'gwt-CheckBox\')])[6]')), 'Preferences Auto Paren');
+  chePreferencesAutoBraces = new Button (element(by.xpath('(.//*[contains (@class,\'gwt-CheckBox\')])[7]')), 'Preferences Auto Braces');
   chePreferencesStoreChanges = new Button (element(by.xpath('.//*[@id=\'window-preferences-storeChanges\']')), 'Preferences store changes button');
   chePreferencesClose = new Button (element(by.xpath('.//*[@id=\'window-preferences-close\']')), 'Preferences close button');
+
+  /* Preview link for app as deployed in Che preview */
+  previewLink (usernameGithub: string): Button {
+    let xpathString = './/a[contains (@class,\'gwt-Anchor\')][contains(text(),\'' + usernameGithub + '-che\')]';
+    return new Button (element(by.xpath(xpathString)), 'Che preview link');
+  }
 
   /* Project name as displayed in project explorer */
   recentProjectRootByName (projectName: string): ElementFinder {
@@ -102,53 +105,53 @@ export class SpaceCheWorkspacePage extends AppPage {
     return element(by.xpath(xpathString));
   }
 
-/* Locate folder/file elements in the project tree in Che */
-chePathElement (elementString: string): ElementFinder {
-  let xpathString = '(.//*[contains (@path,\'' + elementString + '\')])[1]';
-  return element(by.xpath(xpathString));
-}
+  /* Locate folder/file elements in the project tree in Che */
+  chePathElement (elementString: string): ElementFinder {
+    let xpathString = '(.//*[contains (@path,\'' + elementString + '\')])[1]';
+    return element(by.xpath(xpathString));
+  }
 
-/* And locate the folder expansion icon for folder elements in the project tree in Che */
-chePathElementIcon (elementString: string): Button {
-  let xpathString = './/*[contains (@path,\'' + elementString + '\')]//*[contains(@id,\'Layer_1\')]';
-  return new Button (element(by.xpath(xpathString)), 'Folder tree element');
-}
+  /* And locate the folder expansion icon for folder elements in the project tree in Che */
+  chePathElementIcon (elementString: string): Button {
+    let xpathString = './/*[contains (@path,\'' + elementString + '\')]//*[contains(@id,\'Layer_1\')]';
+    return new Button (element(by.xpath(xpathString)), 'Folder tree element');
+  }
 
-/* Locate folder/file element in the project tree in Che */
-cheFileName (elementString: string): Button {
-  let xpathString = './/*[contains (@class,\'GDPEHSMCNBB\')]//*[contains(text(),\'' + elementString + '\')]';
-  return new Button (element(by.xpath(xpathString)), 'The filename in Che');
-}
+  /* Locate folder/file element in the project tree in Che */
+  cheFileName (elementString: string): Button {
+    let xpathString = './/*[contains (@class,\'GDPEHSMCNBB\')]//*[contains(text(),\'' + elementString + '\')]';
+    return new Button (element(by.xpath(xpathString)), 'The filename in Che');
+  }
 
-/* Given a set of parameters where each parameter is a folder or class, "walk"
+  /* Given a set of parameters where each parameter is a folder or class, "walk"
    (traverse) project tree in Che, expanding each element */
-async walkTree (...theArgs: string[]) {
-  let xpathString: string = '';
-  for (let i = 0; i < theArgs.length; i++) {
-    xpathString += theArgs[i];
+  async walkTree (...theArgs: string[]) {
+    let xpathString: string = '';
+    for (let i = 0; i < theArgs.length; i++) {
+      xpathString += theArgs[i];
 
-    await this.chePathElementIcon(xpathString).clickWhenReady();
-    let theText = await this.chePathElement(xpathString).getText();
-    support.info ('Opened path = ' + theText);
-    await browser.sleep(5000);
+      await this.chePathElementIcon(xpathString).clickWhenReady();
+      let theText = await this.chePathElement(xpathString).getText();
+      support.info ('Opened path = ' + theText);
+      await browser.sleep(5000);
+    }
   }
-}
 
-cheWorkspaceName(): string {
-  if (!isUndefined(this.url)) {
-    return this.url.substr(this.url.lastIndexOf('/'));
-  } else {
-    return '';
+  cheWorkspaceName(): string {
+    if (!isUndefined(this.url)) {
+      return this.url.substr(this.url.lastIndexOf('/'));
+    } else {
+      return '';
+    }
   }
-}
 
-cheWorkspaceUrl(): string {
-  if (!isUndefined(this.url)) {
-    return this.url;
-  } else {
-    return '';
+  cheWorkspaceUrl(): string {
+    if (!isUndefined(this.url)) {
+      return this.url;
+    } else {
+      return '';
+    }
   }
-}
 // tslint:enable:max-line-length
 
 }

--- a/ee_tests/src/support/launcher_runtime.ts
+++ b/ee_tests/src/support/launcher_runtime.ts
@@ -7,6 +7,7 @@ export class LauncherRuntime {
 
   id: string;
   name: string;
+  quickstartStartedTerminal: string;
 
   static runtime(id: string) {
     return new LauncherRuntime(id);
@@ -18,21 +19,28 @@ export class LauncherRuntime {
     switch (runtime) {
       case LauncherRuntime.SPRING_BOOT: {
         this.name = 'Spring Boot';
+        this.quickstartStartedTerminal = 'Setting the server\'s publish address to be';
         break;
       }
       case LauncherRuntime.NODE_JS: {
         this.name = 'Node.js';
+        // TODO: implement
+        this.quickstartStartedTerminal = '// TODO: implement';
         break;
       }
       case LauncherRuntime.WILDFLY_SWARM: {
         this.name = 'Wildfly Swarm';
+        // TODO: implement
+        this.quickstartStartedTerminal = '// TODO: implement';
         break;
       }
       case LauncherRuntime.VERTX:
       default: {
         this.name = 'Eclipse Vert.x';
+        this.quickstartStartedTerminal = 'Succeeded in deploying verticle';
         break;
       }
     }
   }
 }
+

--- a/ee_tests/ts-protractor.sh
+++ b/ee_tests/ts-protractor.sh
@@ -68,6 +68,7 @@ main() {
     --params.login.password="$OSIO_PASSWORD" \
     --params.github.username="$GITHUB_USERNAME" \
     --params.github.password="$GITHUB_PASSWORD" \
+    --params.oso.username="$OSO_USERNAME" \
     --params.target.url="$OSIO_URL" \
     --params.quickstart.name="$QUICKSTART_NAME" \
     --params.release.strategy="$RELEASE_STRATEGY" \


### PR DESCRIPTION
New pull request to replace: https://github.com/fabric8io/fabric8-test/pull/558

In this new pull request:
* New test is added to verify a deployed app's endpoint in the Che preview URL
* New test is added to modify an app's source and then verify deployed app's endpoint in the Che preview URL

These tests are running successfully 95%+ of the time when run locally (In Boston). Failures were seen in Brno in running https://github.com/fabric8io/fabric8-test/pull/558 - the theory is that network latency was the cause of these errors. We need to verify with the tests in this new pull request - and also run the tests in other geographic locations to determine if location is a factor.