### PR TITLE
Removed expec for build status (resolved #581)

### DIFF
--- a/ee_tests/src/interactions/pipelines_interactions.ts
+++ b/ee_tests/src/interactions/pipelines_interactions.ts
@@ -56,7 +56,6 @@ export abstract class PipelinesInteractions {
         let pipeline = pipelines[0];
         expect(await pipeline.getApplicationName()).toBe(this.spaceName, 'application name');
         expect(await pipeline.getBuildNumber()).toBe(1, 'build number');
-        expect(await pipeline.getStatus()).toBe(BuildStatus.NEW, 'build status');
 
         let githubName = browser.params.github.username;
         expect(await pipeline.getRepository()).


### PR DESCRIPTION
As the che test was introduced to run before pipelines test, we cannot
assume that the status of build upon page load is NEW.