### PR TITLE
Tagging of docker images

### DIFF
--- a/ee_tests/Dockerfile.builder
+++ b/ee_tests/Dockerfile.builder
@@ -4,7 +4,6 @@ ENV NODE_VERSION 6.11.4
 ENV DISPLAY=:99
 
 WORKDIR /opt/fabric8-test/
-ENTRYPOINT ["./docker-entrypoint.sh"]
 VOLUME /dist
 
 # load the gpg keys

--- a/ee_tests/cico_build_deploy.sh
+++ b/ee_tests/cico_build_deploy.sh
@@ -21,7 +21,6 @@ if [ -n "${BUILD_NUMBER}" ]; then
   service docker start
 fi
 
-
 IMAGE="fabric8-test"
 REPOSITORY="fabric8io"
 REGISTRY="push.registry.devshift.net"
@@ -29,27 +28,39 @@ REGISTRY="push.registry.devshift.net"
 # Build image
 docker build -t ${IMAGE} -f Dockerfile.builder .
 
-## All ok, deploy
-if [ $? -eq 0 ]; then
-  echo 'CICO: build OK'
+if [ ! $? -eq 0 ]; then
+  echo 'CICO: Image build failed'
+  exit 1
+fi
+echo 'CICO: Build OK'
 
-  if [ -z "${BUILD_NUMBER}" ]; then
-    exit 0
-  fi
-
-  if [ -n "${DEVSHIFT_USERNAME}" ] && [ -n "${DEVSHIFT_PASSWORD}" ]; then
-      docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${REGISTRY}
-  fi
-
-  docker tag ${IMAGE} ${REGISTRY}/${REPOSITORY}/${IMAGE}:latest && \
-  docker push ${REGISTRY}/${REPOSITORY}/${IMAGE}:latest
-  if [ $? -eq 0 ]; then
-    echo 'CICO: image pushed, npmjs published, ready to update deployed app'
-    exit 0
-  else
-    echo 'CICO: Image push to registry failed'
-    exit 2
-  fi
+if [ -z "${BUILD_NUMBER}" ]; then
+  exit 0
 fi
 
+# returns something like "Google Chrome 66.0.3359.117"
+TMP=`docker run --rm fabric8-test google-chrome --version`
+# convert to array of words
+TMP=($TMP)
+if [ ! ${#TMP[*]} -eq 3 ]; then
+  echo "CICO: The output of command 'google-chrome --version' probably changed, update this script";
+  exit 2
+fi
+TAG=${TMP[2]}
 
+if [ -n "${DEVSHIFT_USERNAME}" ] && [ -n "${DEVSHIFT_PASSWORD}" ]; then
+  docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${REGISTRY}
+fi
+
+docker tag ${IMAGE} ${REGISTRY}/${REPOSITORY}/${IMAGE}:latest && \
+docker tag ${IMAGE} ${REGISTRY}/${REPOSITORY}/${IMAGE}:${TAG} && \
+docker push ${REGISTRY}/${REPOSITORY}/${IMAGE}:latest && \
+docker push ${REGISTRY}/${REPOSITORY}/${IMAGE}:${TAG}
+
+if [ $? -eq 0 ]; then
+  echo 'CICO: Image pushed, ready to update deployed app'
+  exit 0
+else
+  echo 'CICO: Image push to registry failed'
+  exit 3
+fi

--- a/ee_tests/cico_run_EE_tests_ts.sh
+++ b/ee_tests/cico_run_EE_tests_ts.sh
@@ -83,6 +83,9 @@ docker run --detach=true --name=fabric8-test --cap-add=SYS_ADMIN \
           -e "CI=true" -t -v $(pwd)/dist:/dist:Z -v $PWD/password_file:/opt/fabric8-test/password_file \
           -v $PWD/jenkins-env:/opt/fabric8-test/jenkins-env ${REGISTRY}/${REPOSITORY}/${IMAGE}:latest
 
+# Start Xvfb
+docker exec fabric8-test /usr/bin/Xvfb :99 -screen 0 1024x768x24 &
+
 # Exec EE tests
 docker exec fabric8-test ./ts-protractor.sh $TEST_SUITE | tee theLog.txt
 

--- a/ee_tests/docker-entrypoint.sh
+++ b/ee_tests/docker-entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-echo -n Running Xvfb...
-/usr/bin/Xvfb :99 -screen 0 1024x768x24

--- a/ee_tests/local_cico_run_ee_tests.sh
+++ b/ee_tests/local_cico_run_ee_tests.sh
@@ -23,6 +23,9 @@ docker run --detach=true --name=fabric8-test --cap-add=SYS_ADMIN \
           -e RESET_ENVIRONMENT -e DEBUG -e "API_URL=http://api.openshift.io/api/" \
           -t -v $(pwd)/dist:/dist:Z fabric8-test:latest
 
+# Start Xvfb
+docker exec fabric8-test /usr/bin/Xvfb :99 -screen 0 1024x768x24 &
+
 # Exec EE tests
 docker exec fabric8-test ./ts-protractor.sh $TEST_SUITE | tee target/theLog.txt
 


### PR DESCRIPTION
1. remove ENTRYPOINT in `Dockerfile.builder` so that Chrome version can be obtained safely
2. tag Docker image with not only `latest` but also with Chrome version (e.g. `66.0.3359.117`)

TODO do we need to re-sync source files in case that tests start using tagged version instead of `latest`? Can we postpone this?