### PR TITLE
Added video reporter

### DIFF
--- a/ee_tests/Dockerfile.builder
+++ b/ee_tests/Dockerfile.builder
@@ -58,6 +58,11 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
 # FIXME: Firefox complains about a missing machine-id file. So I set a random one
 # echo 8636d9aff3933f48b95ad94891cd1839 > /var/lib/dbus/machine-id
 
+# Install ffmpeg for video capturing
+# RUN yum -y --setopt tsflags='nodocs' localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm \
+# https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-7.noarch.rpm \
+# && yum -y --setopt tsflags='nodocs' install ffmpeg
+
 # Provide oc client to tests Clean up the test user account's resources in OpenShift Online
 RUN wget https://github.com/openshift/origin/releases/download/v1.5.0/openshift-origin-client-tools-v1.5.0-031cbe4-linux-64bit.tar.gz &&\
     tar -xzvf openshift-origin-client-tools-v1.5.0-031cbe4-linux-64bit.tar.gz &&\

--- a/ee_tests/declarations.d.ts
+++ b/ee_tests/declarations.d.ts
@@ -3,3 +3,4 @@ declare module "protractor-jasmine2-screenshot-reporter";
 declare module "jasmine-spec-reporter";
 declare module "jasmine-protractor-matchers";
 declare module 'protractor-fail-fast';
+declare module 'protractor-video-reporter';

--- a/ee_tests/package-lock.json
+++ b/ee_tests/package-lock.json
@@ -20,9 +20,9 @@
       }
     },
     "@types/node": {
-      "version": "8.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.4.tgz",
-      "integrity": "sha512-dSvD36qnQs78G1BPsrZFdPpvLgMW/dnvr5+nTW2csMs5TiP9MOXrjUbnMZOEwnIuBklXtn7b6TPA2Cuq07bDHA==",
+      "version": "8.10.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.9.tgz",
+      "integrity": "sha512-GUUTbeDaJSRaoLkqVQ5jwwKbDiLWFX3JrKLvC078q2P51Z9Dcb5F5UdnApSYqdMk4X0VrKod1gzeoX8bGl8DMg==",
       "dev": true
     },
     "@types/q": {
@@ -138,9 +138,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
       "dev": true
     },
     "babel-code-frame": {
@@ -343,7 +343,7 @@
       "requires": {
         "globby": "5.0.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
@@ -555,7 +555,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "sshpk": "1.14.1"
       }
     },
     "https-proxy-agent": {
@@ -604,9 +604,9 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
         "is-path-inside": "1.0.1"
@@ -631,6 +631,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isemail": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
       "dev": true
     },
     "isstream": {
@@ -696,6 +702,18 @@
       "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-2.2.0.tgz",
       "integrity": "sha1-43zwsX8ZnM4jvqcbIDk5Uka07E4=",
       "dev": true
+    },
+    "joi": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-8.4.2.tgz",
+      "integrity": "sha1-vXd0ZY/pkFjYmU7R1LmWJITruFk=",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.1",
+        "isemail": "2.2.1",
+        "moment": "2.22.1",
+        "topo": "2.0.2"
+      }
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -834,6 +852,12 @@
         "minimist": "0.0.8"
       }
     },
+    "moment": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
+      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -941,12 +965,12 @@
       "dev": true
     },
     "protractor": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.3.0.tgz",
-      "integrity": "sha512-8z1TWtc/I9Kn4fkfg87DhkSAi0arul7DHBEeJ70sy66teQAeffjQED1s0Gduigme7hxHRYdYEKbhHYz28fpv5w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.3.1.tgz",
+      "integrity": "sha512-AW9qJ0prx2QEMy1gnhJ1Sl1WBQL2R3fx/VnG09FEmWprPIQPK14t0B83OB/pAGddpxiDCAAV0KiNNLf2c2Y/lQ==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.101",
+        "@types/node": "6.0.106",
         "@types/q": "0.0.32",
         "@types/selenium-webdriver": "2.53.43",
         "blocking-proxy": "1.0.1",
@@ -964,9 +988,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.101",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+          "version": "6.0.106",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.106.tgz",
+          "integrity": "sha512-U4Zv5fx7letrisRv6HgSSPSY00FZM4NMIkilt+IAExvQLuNa6jYVwCKcnSs2NqTN4+KDl9PskvcCiMce9iePCA==",
           "dev": true
         },
         "adm-zip": {
@@ -1000,7 +1024,7 @@
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "q": "1.4.1",
-            "request": "2.83.0",
+            "request": "2.85.0",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
             "xml2js": "0.4.19"
@@ -1039,6 +1063,29 @@
         }
       }
     },
+    "protractor-video-reporter": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/protractor-video-reporter/-/protractor-video-reporter-0.3.0.tgz",
+      "integrity": "sha1-qAeIyHG+itsGaufVTk99mPU1tuk=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "joi": "8.4.2",
+        "lodash": "4.17.5",
+        "mkdirp": "0.5.1",
+        "node-uuid": "1.4.8",
+        "sanitize-filename": "1.6.1",
+        "subtitles-parser": "0.0.2"
+      },
+      "dependencies": {
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        }
+      }
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -1072,13 +1119,13 @@
       }
     },
     "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
+        "aws4": "1.7.0",
         "caseless": "0.12.0",
         "combined-stream": "1.0.6",
         "extend": "3.0.1",
@@ -1124,6 +1171,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
+    },
+    "sanitize-filename": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
+      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
+      "dev": true,
+      "requires": {
+        "truncate-utf8-bytes": "1.0.2"
+      }
     },
     "saucelabs": {
       "version": "1.3.0",
@@ -1189,9 +1245,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "dev": true,
       "requires": {
         "asn1": "0.2.3",
@@ -1231,6 +1287,12 @@
         "ansi-regex": "2.1.1"
       }
     },
+    "subtitles-parser": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/subtitles-parser/-/subtitles-parser-0.0.2.tgz",
+      "integrity": "sha1-zy/MPjl7HH+DHhNl9rPON9MVUZQ=",
+      "dev": true
+    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -1246,6 +1308,15 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "topo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.1"
+      }
+    },
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
@@ -1253,6 +1324,15 @@
       "dev": true,
       "requires": {
         "punycode": "1.4.1"
+      }
+    },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "dev": true,
+      "requires": {
+        "utf8-byte-length": "1.0.4"
       }
     },
     "tslib": {
@@ -1319,22 +1399,22 @@
       }
     },
     "tslint-loader": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/tslint-loader/-/tslint-loader-3.5.3.tgz",
-      "integrity": "sha1-ND90Ei2U81a2iUV9P1n2SmmrYG8=",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tslint-loader/-/tslint-loader-3.6.0.tgz",
+      "integrity": "sha512-Me9Qf/87BOfCY8uJJw+J7VMF4U8WiMXKLhKKKugMydF0xMhMOt9wo2mjYTNhwbF9H7SHh8PAIwRG8roisTNekQ==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
         "mkdirp": "0.5.1",
         "object-assign": "4.1.1",
         "rimraf": "2.6.2",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       },
       "dependencies": {
         "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         }
       }
@@ -1374,6 +1454,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
+      "dev": true
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
       "dev": true
     },
     "util-deprecate": {

--- a/ee_tests/package.json
+++ b/ee_tests/package.json
@@ -41,14 +41,15 @@
   "devDependencies": {
     "@types/jasmine": "^2.8.6",
     "@types/jasminewd2": "^2.0.3",
-    "@types/node": "^8.9.4",
+    "@types/node": "^8.10.9",
     "jasmine-protractor-matchers": "^2.0.0",
     "jasmine-spec-reporter": "^4.2.1",
-    "protractor": "^5.3.0",
+    "protractor": "^5.3.1",
     "protractor-fail-fast": "^3.1.0",
     "protractor-jasmine2-screenshot-reporter": "^0.5.0",
+    "protractor-video-reporter": "^0.3.0",
     "tslint": "^5.9.1",
-    "tslint-loader": "^3.5.0",
+    "tslint-loader": "^3.6.0",
     "typescript": "2.5.3"
   },
   "repository": {

--- a/ee_tests/protractor.config.ts
+++ b/ee_tests/protractor.config.ts
@@ -1,18 +1,36 @@
 import { Config, browser } from 'protractor';
 import { SpecReporter } from 'jasmine-spec-reporter';
-import * as failFast from 'protractor-fail-fast';
+import * as failFast from 'protractor-fail-fast'; 
+import * as VideoReporter from 'protractor-video-reporter';
 
 // NOTE: weird import as documented in
 // https://github.com/Xotabu4/jasmine-protractor-matchers
 import ProtractorMatchers = require('jasmine-protractor-matchers');
 import HtmlScreenshotReporter = require('protractor-jasmine2-screenshot-reporter');
 
-let reporter = new HtmlScreenshotReporter({
+let screenshotReporter = new HtmlScreenshotReporter({
   dest: 'target/screenshots',
-  filename: 'my-report.html',
+  filename: 'f8-test-report.html',
   reportOnlyFailedSpecs: false,
   captureOnlyFailedSpecs: false,
   inlineImages: true
+});
+
+let consoleReporter = new SpecReporter({
+  spec: {
+    displayStacktrace: true,
+    displayDuration: true
+  },
+  summary: {
+    displayDuration: true
+  }
+});
+
+// To use video capturing reporter you need to have ffmpeg installed
+let useVideoReporter = false;
+
+let videoReporter = new VideoReporter({
+  baseDirectory: 'target/videos'
 });
 
 // Full protractor configuration file reference could be found here:
@@ -101,21 +119,16 @@ let conf: Config = {
 
   // Setup the report before any tests start
   beforeLaunch: function() {
-    return new Promise(resolve => reporter.beforeLaunch(resolve));
+    return new Promise(resolve => screenshotReporter.beforeLaunch(resolve));
   },
 
   // Assign the test reporter to each running instance
   onPrepare: function() {
-    jasmine.getEnv().addReporter(reporter);
-    jasmine.getEnv().addReporter(new SpecReporter({
-      spec: {
-        displayStacktrace: true,
-        displayDuration: true
-      },
-      summary: {
-        displayDuration: true
-      }
-    }));
+    jasmine.getEnv().addReporter(screenshotReporter);
+    jasmine.getEnv().addReporter(consoleReporter);
+    if (useVideoReporter) {
+      jasmine.getEnv().addReporter(videoReporter);
+    }
 
     beforeEach(() => {
       jasmine.addMatchers(ProtractorMatchers);
@@ -124,7 +137,7 @@ let conf: Config = {
 
   // Close the report after all tests finish
   afterLaunch: function(exitCode) {
-    return new Promise(resolve => reporter.afterLaunch(resolve(exitCode)));
+    return new Promise(resolve => screenshotReporter.afterLaunch(resolve(exitCode)));
   }
 };
 


### PR DESCRIPTION
The reporter is intended to be used mainly in Docker image. On local
machine, it needs to have ffmpeg installed and might or might not work
well (dependeing on the system configuration).

Use: you need to enable reporter in protractor.config.ts. (set
useVideoReporter=true) and uncomment ffmpeg instalation in
Dockerfile.builder. The video will be stored in target/videos.