### PR TITLE
fix(test): resolve logout error for booster suite

### DIFF
--- a/ee_tests/src/booster_ee_int_tests/booster_cleanup.spec.ts
+++ b/ee_tests/src/booster_ee_int_tests/booster_cleanup.spec.ts
@@ -42,6 +42,7 @@ describe('Clean up user environment:', () => {
     support.debug('>>> Go to Reset Env Page - OK');
 
     await cleanupEnvPage.cleanup(browser.params.login.user);
+    await cleanupEnvPage.dashboardButton.clickWhenReady();
   });
 
 });

--- a/ee_tests/src/page_objects/user_profile.page.ts
+++ b/ee_tests/src/page_objects/user_profile.page.ts
@@ -1,5 +1,6 @@
 import { browser, by, ExpectedConditions as until, $, element } from 'protractor';
 import * as support from '../support';
+import { TextInput, Button, BaseElement } from '../ui';
 
 import { AppPage } from './app.page';
 
@@ -41,7 +42,8 @@ export class CleanupUserEnvPage extends AppPage {
   );
 
   alertBox = new ui.BaseElement($('#overview div.alert'), 'Alert Box');
-
+  dashboardButton = new Button(element (by.xpath('.//button[contains(text(),\'Take me to my Dashboard\')]')),
+  'Take me to my Dashboard button');
 
   constructor() {
     super();


### PR DESCRIPTION
I'm not sure if the UI changed, but without this pull request, the booster suite fails to logout as the search for the absence of the successful env reset alert always fails.