### PR TITLE
ee_tests: Clear confirmation input before entering username.

### DIFF
--- a/ee_tests/src/page_objects/user_profile.page.ts
+++ b/ee_tests/src/page_objects/user_profile.page.ts
@@ -88,6 +88,7 @@ export class CleanupUserEnvPage extends AppPage {
     let confirmationElement =  this.innerElement(ui.BaseElement, 'modal', '');
     let confirmationBox = new CleanupConfirmationModal(confirmationElement);
     await confirmationBox.ready();
+    await confirmationBox.confirmationInput.clear();
     await confirmationBox.confirmationInput.enterText(username);
     await confirmationBox.confirmEraseButton.clickWhenReady();
   }


### PR DESCRIPTION
In case a second `Reset environment` is needed in the cleanup phase, the username (e.g. `user_name`) remains filled in from the previous attempt so entering it a second time causes it to be invalid (`user_nameuseruser_name`). So I added a line to clean the input box before it is filled with the user name.