### PR TITLE
fix(test): the new launcher is now in both production and beta

### DIFF
--- a/ee_tests/src/interactions/account_home_interactions.ts
+++ b/ee_tests/src/interactions/account_home_interactions.ts
@@ -61,7 +61,7 @@ export class ReleasedAccountHomeInteractions extends AbstractSpaceDashboardInter
     }
 
     public async createSpace(name: string): Promise<void> {
-        await this.dashboardPage.createNewSpace(name);
+        await this.dashboardPage.createNewSpaceByLauncher(name);
     }
 
     public async resetEnvironment(): Promise<void> {
@@ -77,7 +77,4 @@ export class ReleasedAccountHomeInteractions extends AbstractSpaceDashboardInter
 
 export class BetaAccountHomeInteractions extends ReleasedAccountHomeInteractions {
 
-    public async createSpace(name: string): Promise<void> {
-        await this.dashboardPage.createNewSpaceByLauncher(name);
-    }
 }

--- a/ee_tests/src/interactions/space_dashboard_interactions.ts
+++ b/ee_tests/src/interactions/space_dashboard_interactions.ts
@@ -104,7 +104,7 @@ export class ReleasedSpaceDashboardInteractions extends AbstractSpaceDashboardIn
 
     public async createQuickstart(name: string, strategy: string): Promise<void> {
         let wizard = await this.spaceDashboardPage.addToSpace();
-        await wizard.newQuickstartProject({ project: name, strategy });
+        await wizard.newQuickstartProjectByLauncher(name, this.spaceName, strategy);
     }
 
     public async verifyCodebases(): Promise<void> {
@@ -160,11 +160,6 @@ export class ReleasedSpaceDashboardInteractions extends AbstractSpaceDashboardIn
 }
 
 export class BetaSpaceDashboardInteractions extends ReleasedSpaceDashboardInteractions {
-
-    public async createQuickstart(name: string, strategy: string): Promise<void> {
-        let wizard = await this.spaceDashboardPage.addToSpace();
-        await wizard.newQuickstartProjectByLauncher(name, this.spaceName, strategy);
-    }
 
     public async verifyWorkItems(): Promise<void> {
         let workItemsCard = await this.spaceDashboardPage.getWorkItemsCard();


### PR DESCRIPTION
The old launcher is no longer available to users - the tests should not attempt to use the old launcher. Users configured for both beta and released features will only see the new launcher.