### PR TITLE
CICO run script fixed to filter env variables correctly

### DIFF
--- a/ee_tests/cico_run_e2e_tests.sh
+++ b/ee_tests/cico_run_e2e_tests.sh
@@ -15,9 +15,9 @@ chmod 600 ./password_file
 if [ -e "../jenkins-env" ]; then
   cat ../jenkins-env \
     | grep -E "(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|JOB_NAME|BUILD_NUMBER|ghprbSourceBranch|\
-    ghprbActualCommit|BUILD_URL|ghprbPullId|RESET_ENVIRONMENT|\
-    OSIO_CLUSTER|OSIO_USERNAME|OSIO_PASSWORD|TEST_SUITE|OSIO_URL|GITHUB_USERNAME|GITHUB_REPO|\
-    QUICKSTART_NAME|RELEASE_STRATEGY|FEATURE_LEVEL|ZABBIX_ENABLED)=" \
+    |ghprbActualCommit|BUILD_URL|ghprbPullId|RESET_ENVIRONMENT|\
+    |OSIO_CLUSTER|OSIO_USERNAME|OSIO_PASSWORD|TEST_SUITE|OSIO_URL|GITHUB_USERNAME|GITHUB_REPO|\
+    |QUICKSTART_NAME|RELEASE_STRATEGY|FEATURE_LEVEL|ZABBIX_ENABLED)=" \
     | sed 's/^/export /g' \
     > /tmp/jenkins-env
   source /tmp/jenkins-env


### PR DESCRIPTION
Right now, Jenkins jobs generate `zabbix-report.txt` file containing lines like this:

```
 beta.smoketest.login 1527154649079 38.879
```

but expected value is something like this:

```
us-east-1b beta.smoketest.login 1527154649079 38.879
```

Line break in the bash script causes variables not being filtered correctly.