### PR TITLE
fix(test) remove outdated sections of README

### DIFF
--- a/ee_tests/README.md
+++ b/ee_tests/README.md
@@ -50,10 +50,6 @@ implement the test.
 npm start local
 ```
 
-## The rest of the documentation should be reviewed
-
-
-
 ##### Debugging #####
 
 You can use chrome devtools to pause and debug typescript tests by inserting
@@ -77,106 +73,5 @@ variable before you start script mentioned above:
 ```
 SELENIUM_BROWSER=firefox
 ```
-
-### End-to-End Tests on Fabric8
-
-To run against a fabric8 installation (e.g. via minishift) run the following command:
-
-
-```
-./local_run_EE_fabric8_test.sh
-```
-
-### Running the Tests in Intellij IDEA
-
-You can run the E2E tests directly in IDEA which makes it super easy to link
-from failures to protractor test code when there are failures or to set
-breakpoints and to debug the tests.
-
-There is some background on [running protractor in IDEA here](https://www.jetbrains.com/help/idea/run-debug-configuration-protractor.html).
-
-Basically try this:
-
-```
-cd ee_tests
-npm install -g yarn
-yarn
-npm run webdriver:update
-npm run webdriver:start 2>&1 | tee webdriver.log
-```
-
-Then in IDEA:
-
-* click the `Run -> Edit Configurations...` button in IDEA
-* select the `+` to add a new runtime configuration and select `Protractor`
-* find the `protractorEE-env.config.js` file as the test suite to run
-* define the following environment variables:
-  * USERNAME (the username on RHD for https://openshift.io or github for fabric8)
-  * PASSWORD (the password for RHD / github like above)
-  * TARGET_URL (if you want to point at something other than https://openshift.io/)
-  * you may want to define [some of these other environment variables](https://github.com/fabric8io/fabric8-test/blob/master/ee_tests/protractorEE-env.config.js#L17) too
-* now just click the Run / Debug button in IDEA!
-* if a test fails you should have nice links in the output to source lines - you can also set breakpoints and debug the tests!
-
-
-## Running the Tests Inside a Pod
-
-You can run the E2E tests on a running fabric8 cluster using the [gofabric8](https://github.com/fabric8io/gofabric8/releases) CLI tool.
-
-First you need to add a `Secret` for a username/password you wish to use to test your cluster. If you've not created one yet you can do that via the CLI:
-
-```
-gofabric8 e2e-secret --user=MYUSER --password=MYPWD --secret=MYNAME
-```
-
-This command will generate a secret called `MYNAME` using your username/password values of `MYUSER/MYPWD`
-
-Now that there is a `Secret` defined in your current namespace you can run the E2E tests using this secret via:
-
-```
-gofabric8 e2e
-```
-
-if you have your own fork of this repository you can refer to your own fork and a branch of the tests via something like this:
-
-```
-gofabric8 e2e --repo https://github.com/jstrachan/fabric8-test.git --branch new-script
-```
-
-### Arguments
-
-You can specify a number of different CLI arguments to parameterize the E2E tests to configure things like custom Tenant YAMLs to test (e.g. PRs against the YAMLs) or custom boosters.
-
-To see a list of all the current options type:
-
-```
-gofabric8 help e2e
-```
-
-For each argument name `foo` you pass the argument using `--foo=value` or `--foo value` like the above examples for passing in `repo` and `branch` arguments.
-
-#### Cluster
-
-* `url` : the URL of the remote fabric8 console. If not specified it uses the URL of the current `fabric8` service in the current namespace (or the specified `namespace` argument)
-* `platform` : the kind of platform to test. e.g. `osio`, `fabric8-openshift` or `fabric8-kubernetes`. Typically you can ignore this argument as gofabric8 will deadfult this for you
-
-#### Custom Boosters
-
-*  `booster` : the name of the booster (quickstart) to use in the tests
-*  `booster-git-ref` : the booster git repository reference (branch, tag, sha)
-*  `booster-git-repo` : the booster git repository URL to use for the tests - when using a fork or custom catalog"
-
-e.g. to test a custom booster in your own fork try:
-
-```
-gofabric8 e2e --booster="My Booster" --booster-git-ref=mybranch --booster-git-repo=https://github.com/myuser/booster-catalog.git
-```
-
-#### Custom Tenant YAML
-
-*  `che-version` : the Che YAML version for the tenant
-*  `jenkins-version` : the Jenkins YAML version for the tenant
-*  `team-version` : the Team YAML version for the tenant
-*  `maven-repo` : the maven repository used for tenant YAML if using a PR or custom build
 
 


### PR DESCRIPTION
The sections removed are all old and no longer applicable. Let's limit the contents of the README to only current and correct information to assist anyone in running the tests. 