### PR TITLE
fix(config): set template default test suite to valid value

### DIFF
--- a/ee_tests/config/local_osio.conf.sh.template
+++ b/ee_tests/config/local_osio.conf.sh.template
@@ -14,13 +14,11 @@ export GITHUB_PASSWORD="${GITHUB_PASSWORD:-}"
 #export GITHUB_REPO="${$GITHUB_REPO:-testmay-to-be-imported}"
 
 # test params
-export TEST_SUITE="${TEST_SUITE:-runTest}"
+# see protractor.config.ts for valid test suites
+export TEST_SUITE="${TEST_SUITE:-smoketest}"
 export RELEASE_STRATEGY="${RELEASE_STRATEGY:-releaseStageApproveAndPromote}"
 export QUICKSTART_NAME="${QUICKSTART_NAME:-'vertxHttp'}"
 export NGX_LAUNCHER_ENABLED="${NGX_LAUNCHER_ENABLED:-true}"
 export RESET_ENVIRONMENT="${RESET_ENVIRONMENT:-true}"
 # Expected user setting for feature levels - internal, experimental, beta, released
 export FEATURE_LEVEL="${FEATURE_LEVEL:-internal}"
-
-
-


### PR DESCRIPTION
This sets the default value of `TEST_SUITE` for the config template to a valid value, `all`. A comment is also added so users are informed of where they can look for the list of existing test suites and extra new lines are removed (I guess my IDE did that...)

Thoughts? I'm open to a different default test suite, however as a user, I'd prefer one that's at least valid.