### PR TITLE
E2E: run scripts updated to set local timezone in Docker container

### DIFF
--- a/ee_tests/cico_run_e2e_tests.sh
+++ b/ee_tests/cico_run_e2e_tests.sh
@@ -74,6 +74,7 @@ docker run --shm-size=256m --detach=true --name=$CONTAINER_NAME --cap-add=SYS_AD
           -e ZABBIX_ENABLED -e ZABBIX_HOST -e ZABBIX_METRIC_PREFIX \
           -e ZABBIX_PORT -e ZABBIX_SERVER \
           -t -v $(pwd)/dist:/dist:Z -v $PWD/password_file:/opt/fabric8-test/password_file \
+          -v /etc/localtime:/etc/localtime:ro \
           -v $PWD/jenkins-env:/opt/fabric8-test/jenkins-env ${REGISTRY}/${REPOSITORY}/${IMAGE}:latest
 
 # Start Xvfb

--- a/ee_tests/local_cico_run_e2e_tests.sh
+++ b/ee_tests/local_cico_run_e2e_tests.sh
@@ -21,7 +21,7 @@ docker run --shm-size=256m --detach=true --name=fabric8-test --cap-add=SYS_ADMIN
           -e OSIO_USERNAME -e OSIO_PASSWORD -e OSIO_URL  \
           -e OSO_USERNAME -e GITHUB_USERNAME -e GITHUB_REPO -e TEST_SUITE -e QUICKSTART_NAME -e RELEASE_STRATEGY \
           -e FEATURE_LEVEL -e RESET_ENVIRONMENT -e DEBUG \
-          -t -v $(pwd)/dist:/dist:Z fabric8-test:latest
+          -t -v $(pwd)/dist:/dist:Z -v /etc/localtime:/etc/localtime:ro fabric8-test:latest
 
 # Start Xvfb
 docker exec fabric8-test /usr/bin/Xvfb :99 -screen 0 1024x768x24 &


### PR DESCRIPTION
should work with Fedora and CentOS, not tested with Ubuntu