### PR TITLE
fix(test): Remove trailing "." char - which causes tests to fail

### DIFF
--- a/booster_api/features/20_importBooster.feature
+++ b/booster_api/features/20_importBooster.feature
@@ -1,7 +1,7 @@
 Feature: Import a new Booster into OpenShift.io
  
   Background:
-    Given I have a space created.
+    Given I have a space created
  
   Scenario: Import booster from a GitHub repository
     When I input a name of the GitHub repository with a booster


### PR DESCRIPTION
The "." char causes the test Given statement to result in a mismatch and fail to execute.