### PR TITLE
Script to check all BASH scripts

### DIFF
--- a/self_tests/README.md
+++ b/self_tests/README.md
@@ -28,3 +28,13 @@ The first script measures cyclomatic complexity of all Python sources found in t
 
 The second script measures maintainability index of all Python sources found in the repository. Please see [the following link](https://radon.readthedocs.io/en/latest/commandline.html#the-mi-command) with explanation of this measurement.
 
+
+## Scripts written in BASH
+
+The script named `check-bashscripts.sh` can be used to check all BASH scripts (in fact: all files with the `.sh` extension) for various possible issues, incompatibilies, and caveats. This script can be run w/o any arguments:
+
+```
+./check-bashscripts.sh
+```
+
+Please see [the following link](https://github.com/koalaman/shellcheck) for further explanation, how the ShellCheck works and which issues can be detected.

--- a/self_tests/check-bashscripts.sh
+++ b/self_tests/check-bashscripts.sh
@@ -25,8 +25,10 @@ function check_files() {
     done
 }
 
-pushd ..
-files=$(find . -path "./venv" -prune -o -name '*.sh' -print)
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+pushd "${SCRIPT_DIR}/.."
+files=$(find . -path "./venv" -prune -o -path "./ee_tests/node_modules" -prune -o -name '*.sh' -print)
 check_files "$files"
 popd
 

--- a/self_tests/check-bashscripts.sh
+++ b/self_tests/check-bashscripts.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Script to check all BASH scripts by ShellCheck validator
+
+pass=0
+fail=0
+
+function check_files() {
+    for source in $1
+    do
+        echo "$source"
+        shellcheck -e 2181 -e 1091 "$source"
+        if [ $? -eq 0 ]
+        then
+            echo "    Pass"
+            let "pass++"
+        elif [ $? -eq 2 ]
+        then
+            echo "    Illegal usage (should not happen)"
+            exit 2
+        else
+            echo "    Fail"
+            let "fail++"
+        fi
+    done
+}
+
+pushd ..
+files=$(find . -path "./venv" -prune -o -name '*.sh' -print)
+check_files "$files"
+popd
+
+if [ $fail -eq 0 ]
+then
+    echo "All checks passed for $pass source files"
+else
+    let total=$pass+$fail
+    echo "BASH-related issues should fixed in $fail source files out of $total files"
+    exit 1
+fi
+


### PR DESCRIPTION
This new script can be used to check all BASH scripts for common mistakes, issues, incompatibilities, and caveats.