### PR TITLE
Fix Pylint issues in OSIOperf

### DIFF
--- a/perf_tests/osioperf/scripts/booster-che-workspace/booster-che-workspace.py
+++ b/perf_tests/osioperf/scripts/booster-che-workspace/booster-che-workspace.py
@@ -184,7 +184,7 @@ class UserScenario(TaskSet):
         return failed
 
     def reset_environment(self, driver, failed=False):
-        request_type="setup"
+        request_type = "setup"
 
         metric = "reset-environment"
         if not failed:
@@ -193,17 +193,17 @@ class UserScenario(TaskSet):
                 driver.get(self.locust.host + "/" + self.taskUserName + "/_cleanup")
                 self._wait_for_url(driver, self.locust.host + "/" + self.taskUserName + "/_cleanup")
 
-                target_element= self._wait_for_clickable_element(driver, By.XPATH, "//*[text()='Erase My OpenShift.io Environment']")
+                target_element = self._wait_for_clickable_element(driver, By.XPATH, "//*[text()='Erase My OpenShift.io Environment']")
                 target_element.click()
 
-                target_element= self._wait_for_clickable_element(driver, By.NAME, "username")
+                target_element = self._wait_for_clickable_element(driver, By.NAME, "username")
                 target_element.send_keys(self.taskUserName)
 
-                target_element= self._wait_for_clickable_element(driver, By.XPATH, "//*[text()='I understand my actions - erase my environment']")
+                target_element = self._wait_for_clickable_element(driver, By.XPATH, "//*[text()='I understand my actions - erase my environment']")
                 target_element.click()
 
-                self._wait_for_non_clickable_element(driver, By.XPATH,"//*[contains(@class, 'alert')]")
-                self._wait_for_clickable_element(driver, By.XPATH,"//*[contains(@class, 'alert')]")
+                self._wait_for_non_clickable_element(driver, By.XPATH, "//*[contains(@class, 'alert')]")
+                self._wait_for_clickable_element(driver, By.XPATH, "//*[contains(@class, 'alert')]")
 
                 self._report_success(request_type, metric, self._tick_timer())
             except Exception as ex:
@@ -517,8 +517,8 @@ class UserScenario(TaskSet):
         else:
             self._report_failure(driver, request_type, metric, self._tick_timer(), self.SKIPPED_MSG)
 
-
         metric = "git-provider"
+
         if not failed:
             self._reset_timer()
             try:

--- a/perf_tests/osioperf/scripts/workshop-demo/workshop-demo.py
+++ b/perf_tests/osioperf/scripts/workshop-demo/workshop-demo.py
@@ -230,7 +230,8 @@ class UserScenario(TaskSet):
                 target_element.send_keys(self.taskUserName)
 
                 target_element = self._wait_for_clickable_element(
-                    driver, By.XPATH, "//*[text()='I understand my actions - erase my environment']")
+                    driver, By.XPATH,
+                    "//*[text()='I understand my actions - erase my environment']")
 
                 self._reset_timer()
                 target_element.click()

--- a/perf_tests/setup.cfg
+++ b/perf_tests/setup.cfg
@@ -1,0 +1,3 @@
+[pycodestyle]
+ignore = E121, E126, E402, W504
+max-line-length = 150


### PR DESCRIPTION
Fix most issues found by Pylint. The only thing I left is the line length check - we'd need to decide if it make sense to use one of the standard limit (80, 100, ...) for these tests, because most long lines contain "path"/"selectors"