### PR TITLE
Fix semantic error in exception handling

### DIFF
--- a/booster_bdd/features/src/pipeline.py
+++ b/booster_bdd/features/src/pipeline.py
@@ -105,12 +105,12 @@ class Pipeline(object):
                           )
                     time.sleep(sleepTimer)
 
-            except (IndexError, e):
+            except IndexError as e:
                 print('Unexpected error found: {}'.format(e))
                 print('attempt {} failed - retrying...'.format(counter))
                 time.sleep(sleepTimer)
 
-        # print 'The value of requestFailed = {}'.format(requestFailed)
+        # print('The value of requestFailed = {}'.format(requestFailed))
 
         return requestFailed
 


### PR DESCRIPTION
Sorry @pmacik, I did not catch this issue in yesterday's PM (https://github.com/fabric8io/fabric8-test/pull/853/files), but:

```
except (IndexError, e):
```

is not semantically correct. Well, in fact tuple can be used here, but just for catching multiple exception types, and the syntax is (Python 2.x, Python 3.x):

```
except (Exception1, Exception2) as e:
```

or (Python 2,x, deprecated AFAIK):

```
except (Exception1, Exception2), e:
```