### PR TITLE
booster-bdd: Use pyshould library instead of asserts.

### DIFF
--- a/booster_bdd/features/src/pipeline.py
+++ b/booster_bdd/features/src/pipeline.py
@@ -1,4 +1,3 @@
-import pytest
 import time
 import requests
 import features.src.support.helpers as helpers

--- a/booster_bdd/features/steps/createSpace.py
+++ b/booster_bdd/features/steps/createSpace.py
@@ -1,6 +1,7 @@
 import behave
 from features.src.support import helpers
 from features.src.space import Space
+from pyshould import *
 
 
 @when(u'I input a spacename')
@@ -13,4 +14,4 @@ def step_impl(context):
 @then(u'I should see a new space created')
 def step_impl(context):
     spaceID = helpers.getSpaceID()
-    assert spaceID is not None, "Space not created"
+    spaceID | should_not.be_none().desc("Created space ID")

--- a/booster_bdd/features/steps/importBooster.py
+++ b/booster_bdd/features/steps/importBooster.py
@@ -3,13 +3,14 @@ import os
 from behave import *
 from features.src.importBooster import *
 from features.src.support import *
+from pyshould import *
 
 
 @given(u'I have a space created')
 def step_impl(context):
     global spaceID
     spaceID = helpers.getSpaceID()
-    assert spaceID is not None
+    spaceID | should_not.be_none().desc("Space ID")
 
     print('Attempting to use OSIO booster service intregration POC...')
     global importBooster
@@ -25,6 +26,5 @@ def step_impl(context):
 
 @then(u'I should see the booster imported')
 def step_impl(context):
-    global expected_result
-    expected_result = 'Success'
-    assert expected_result == result
+    global result
+    result | should.equal('Success').desc("Result of importing a GitHub repository")

--- a/booster_bdd/features/steps/loginUser.py
+++ b/booster_bdd/features/steps/loginUser.py
@@ -2,27 +2,28 @@ import os
 import sys
 import behave
 from features.src.support import helpers
+from pyshould import *
 
 
 @given(u'I am unlogged in to OpenShift.io')
 def unlogged_in(context):
-    assert not (helpers.is_user_logged_in())
+    helpers.is_user_logged_in() | should.be_false.desc("User should be logged out.")
 
 
 @given(u'I am logged in to OpenShift.io')
 def logged_in(context):
-    assert helpers.is_user_logged_in()
+    helpers.is_user_logged_in() | should.be_true.desc("User should be logged in.")
 
 
 @when(u'I login to Openshift.io with username and password')
 def login_user(context):
     username = os.getenv("OSIO_USERNAME")
     password = os.getenv("OSIO_PASSWORD")
-    assert username != ""
-    assert password != ""
+    username | should_not.be_empty.desc("OSIO username")
+    password | should_not.be_empty.desc("OSIO password")
     helpers.login_user(username, password)
 
 
 @then(u'I should be logged in to OpenShift.io')
 def then_user_is_logged_in(context):
-    assert helpers.is_user_logged_in()
+    helpers.is_user_logged_in() | should.be_true("User should be logged in.")

--- a/booster_bdd/features/steps/resetEnvironment.py
+++ b/booster_bdd/features/steps/resetEnvironment.py
@@ -1,5 +1,6 @@
 from behave import *
 from features.src.resetEnv import ResetEnvironment
+from pyshould import *
 
 
 @when(u'I reset environment')
@@ -12,4 +13,5 @@ def step_impl(context):
 
 @then(u'I should see clean environment')
 def step_impl(context):
-    assert len(resetEnv.getSpaces()) == 0
+    global resetEnv
+    len(resetEnv.getSpaces()) | should.equal(1).described_as("Number of spaces after environment reset.")

--- a/booster_bdd/features/steps/verifyPipeline.py
+++ b/booster_bdd/features/steps/verifyPipeline.py
@@ -1,5 +1,6 @@
 from behave import *
 from features.src.pipeline import *
+from pyshould import *
 
 
 @given(u'I have imported a booster')
@@ -16,33 +17,34 @@ def step_impl(context):
 
 @then(u'I should see the newly created build in a "New" state"')
 def step_impl(context):
-    assert pipeline.buildStatus(30, 5, 'New'), "Build failed to get to New state."
+    pipeline.buildStatus(30, 5, 'New') | should.be_true.desc("Build failed to get to New state")
 
 
 @then(u'I should see the build in a "Running" state')
 def step_impl(context):
-    assert pipeline.buildStatus(30, 30, 'Running'), "Build failed to get to  Running state."
+    pipeline.buildStatus(30, 30, 'Running') | should.be_true.desc(
+        "Build failed to get to Running state.")
 
 
 @then(u'I should see the build ready to be promoted to "Run" stage')
 def step_impl(context):
-    assert pipeline.buildStatus(30, 30, 'Running',
-                                'openshift.io/jenkins-pending-input-actions-json'
-                                ), "Build failed to get ready to be promoted."
+    pipeline.buildStatus(30, 30, 'Running',
+                         'openshift.io/jenkins-pending-input-actions-json'
+                         ) | should.be_true.desc("Build failed to get ready to be promoted.")
 
 
 @given(u'The build is ready to be promoted to "Run" stage')
 def step_impl(context):
-    assert pipeline.buildStatus(30, 30, 'Running',
-                                'openshift.io/jenkins-pending-input-actions-json'
-                                ), "Build failed to get ready to be promoted."
+    pipeline.buildStatus(30, 30, 'Running',
+                         'openshift.io/jenkins-pending-input-actions-json'
+                         ) | should.be_true.desc("Build failed to get ready to be promoted.")
 
 
 @when(u'I promote the build to "Run" stage')
 def step_impl(context):
-    assert pipeline.promoteBuild()
+    pipeline.promoteBuild() | should.be_true.desc("Build failed to promote to Run stage.")
 
 
 @then(u'I should see the build completed')
 def step_impl(context):
-    assert pipeline.buildStatus(30, 10, 'Complete'), "Build failed to complete."
+    pipeline.buildStatus(30, 10, 'Complete') | should.be_true.desc("Build failed to complete.")

--- a/booster_bdd/features/steps/verifyRun.py
+++ b/booster_bdd/features/steps/verifyRun.py
@@ -1,5 +1,6 @@
 from behave import *
 from features.src.run import *
+from 
 
 
 @given(u'I have verified a booster\'s pipeline has had its deployment to stage verified')
@@ -18,6 +19,5 @@ def step_impl(context):
 
 @then(u'I should see the deployed app running on run')
 def step_impl(context):
-    global expected_result
-    expected_result = 'Success'
-    assert expected_result == result
+    global result
+    result | should.equal('Success').desc("Application is not reachable in the Run stage.")

--- a/booster_bdd/features/steps/verifyStage.py
+++ b/booster_bdd/features/steps/verifyStage.py
@@ -1,6 +1,8 @@
 from behave import *
 from features.src.stage import *
 
+from pyshould import *
+
 
 @given(u'I have verified a booster\'s pipeline has completed')
 def step_impl(context):
@@ -18,6 +20,5 @@ def step_impl(context):
 
 @then(u'I should see the deployed app running on stage')
 def step_impl(context):
-    global expected_result
-    expected_result = 'Success'
-    assert expected_result == result
+    global result
+    result | should.equal('Success').desc("Application is not reachable in the Stage stage.")

--- a/booster_bdd/requirements.txt
+++ b/booster_bdd/requirements.txt
@@ -5,3 +5,4 @@ jmespath==0.9.3
 jsonschema==2.6.0
 requests==2.19.1
 selenium==3.12.0
+pyshould==0.7.1


### PR DESCRIPTION
If Python is started with the -O option (optimizations), the built-in assertions are stripped out and not evaluated.
This replaces the `assert` statements in tests by the `pyshould` library.
