### PR TITLE
e2e: create workspace button behavior changed in prod

### DIFF
--- a/ee_tests/src/interactions/codebases_interactions.ts
+++ b/ee_tests/src/interactions/codebases_interactions.ts
@@ -62,15 +62,10 @@ class CodebasesInteractionsImpl extends AbstractCodebasesInteractions {
 
     public async createAndOpenWorkspace(): Promise<void> {
         await this.page.createWorkspace();
+        await this.page.openWorkspace();
         await support.windowManager.switchToNewWindow();
     }
 }
 
-class ProdPreviewInteractions extends AbstractCodebasesInteractions {
-
-    public async createAndOpenWorkspace(): Promise<void> {
-        await this.page.createWorkspace();
-        await this.page.openWorkspace();
-        await support.windowManager.switchToNewWindow();
-    }
+class ProdPreviewInteractions extends CodebasesInteractionsImpl {
 }


### PR DESCRIPTION
@ldimaggi @pmacik @rgarg1 @ljelinkova  please review and merge, e2e tests are failing in prod because new behavior of button was promoted from prod-preview to prod