### PR TITLE
e2e: unnecessary variables removed from cico_build_deploy.sh

### DIFF
--- a/ee_tests/cico_build_deploy.sh
+++ b/ee_tests/cico_build_deploy.sh
@@ -5,7 +5,7 @@ set -e
 
 # Export needed vars
 set +x
-for var in BUILD_NUMBER BUILD_URL JENKINS_URL GIT_BRANCH GH_TOKEN NPM_TOKEN GIT_COMMIT DEVSHIFT; do
+for var in BUILD_NUMBER DEVSHIFT; do
   export "$(grep ${var} ../jenkins-env | xargs)"
 done
 set -x


### PR DESCRIPTION
Jenkins job https://ci.centos.org/view/Devtools/job/devtools-fabric8-test-build-master/ is broken, this PR fixes that