### PR TITLE
e2e: locator for pipeline status fixed

### DIFF
--- a/ee_tests/src/interactions/pipelines_interactions.ts
+++ b/ee_tests/src/interactions/pipelines_interactions.ts
@@ -268,7 +268,7 @@ abstract class AbstractPipelinesInteractions implements PipelinesInteractions {
         await support.windowManager.switchToNewWindow();
 
         await browser.wait(until.presenceOf(element(by.cssContainingText('h3', 'Status'))));
-        let status = await element(by.xpath('//h3[text()="Status"]/../dl/dd/span')).getText();
+        let status = await element(by.xpath('//h3[text()="Status"]/../dl[1]/dd[1]/span[1]')).getText();
         expect(status).toBe('Complete');
 
         await support.screenshotManager.writeScreenshot('os-pipeline');


### PR DESCRIPTION
there are messages like this in Jenkins log, this PR fixes that:
```
[13:23:32] W/element - more than one element found for locator By(xpath, //h3[text()="Status"]/../dl/dd/span) - the first result will be used
```