### PR TITLE
e2e: do not fail script for cleaning github repos when nothing to delete

### DIFF
--- a/ee_tests/local_clean_test_repos.sh
+++ b/ee_tests/local_clean_test_repos.sh
@@ -26,7 +26,7 @@ REPOS=$(echo "$RESPONSE" | jq -r '.items[].name')
 
 if [[ -z $REPOS ]]; then
   echo "There are no GitHub repositories matching the filter"
-  exit 2
+  exit 0
 fi
 
 echo "************************** WARNING WARNING WARNING *********************************** "


### PR DESCRIPTION
We don't want the Jenkins job fail unnecessarily https://ci.centos.org/view/Devtools/job/devtools-test-e2e-cleanup/315/console 