### PR TITLE
Planner Integration tests

### DIFF
--- a/ee_tests/package.json
+++ b/ee_tests/package.json
@@ -36,8 +36,10 @@
     "typedoc": "typedoc",
     "webdriver:start": "webdriver-manager start",
     "webdriver:update": "webdriver-manager update --gecko false"
+    },
+  "dependencies": {
+    "planner-functional-test": "0.0.3"
   },
-  "dependencies": {},
   "devDependencies": {
     "@types/jasmine": "^2.8.6",
     "@types/jasminewd2": "^2.0.3",

--- a/ee_tests/protractor.config.ts
+++ b/ee_tests/protractor.config.ts
@@ -75,6 +75,7 @@ let conf: Config = {
     boosterjunittest: ['src/booster_ee_int_tests/quickstart_chejunit.spec.js'],
     boostereditortest: ['src/booster_ee_int_tests/quickstart_che_editor.spec.js'],
 
+    planner : ['src/planner.spec.js']
   },
 
   // see: https://github.com/angular/protractor/blob/master/docs/timeouts.md

--- a/ee_tests/src/page_objects/space_settings.page.ts
+++ b/ee_tests/src/page_objects/space_settings.page.ts
@@ -1,0 +1,99 @@
+import { BaseElement, BaseElementArray, Button, Clickable, TextInput } from '../ui';
+import { $, $$, by, element, Key } from 'protractor';
+import * as support from '.././support';
+import { AppPage } from '../page_objects/app.page';
+
+export class SpaceSettings extends AppPage {
+  settings = new BaseElement($('.pficon-settings'), 'Settings');
+  list = new BaseElementArray($$('.list-pf-item'));
+
+   /* UI elements - Areas Tab*/
+  areasTab = new Clickable(
+    element(by.cssContainingText('.nav.navbar-nav.navbar-persistent li>a', 'Areas')),
+    'Areas Tab');
+  addAreasButton = new Button($("[tooltip='Add Areas']"), 'Add Areas Button');
+  createAreaDialog = new BaseElement($('create-area-dialog'), 'create area dialog');
+  areaInputField = new TextInput(this.createAreaDialog.$('#name'), 'Are input field');
+  cancelButton = new Button (this.createAreaDialog.$('.btn.btn-default'), 'cancel button');
+  createButton = new Button (this.createAreaDialog.$('.btn.btn-primary'), 'create button');
+  showAreasChildren = new Clickable($('.toggle-children'), 'show Areas children');
+  modal = new BaseElement($('.modal-backdrop'), 'modal fade');
+  modalFade = new BaseElement($('[aria-hidden="false"]'));
+
+   /* UI elements - Collaborators Tab*/
+  collaboratorsTab = new Clickable(
+    element(by.cssContainingText('.nav.navbar-nav.navbar-persistent li>a', 'Collaborators')),
+    'Collaborators Tab');
+  addCollaboratorsButton = new Clickable($('.table-action-heading'), 'Add Collaborators Button');
+  collaboratorDialog = new BaseElement($('add-collaborators-dialog.add-dialog'), ' Add Collaborators dialog');
+  searchCollaborator = new TextInput(this.collaboratorDialog.$('.ng-input>input'), 'Search Collaborator');
+  collaboratorDropdown = new Clickable(this.collaboratorDialog.$('.scrollable-content'), 'Collaborator dropdown');
+  selectCollaborator = new Clickable(this.collaboratorDropdown.$('.ng-option'), ' select collaborator');
+  addButton = new Button(this.collaboratorDialog.$('.btn.btn-primary'), 'add collborator button');
+  userInfo = new BaseElement($('.user-dropdown__username'), 'user name');
+
+  async clickSettings() {
+    support.info('click settings button');
+    await this.settings.clickWhenReady();
+  }
+
+   /* Areas page*/
+  async clickAreasTab() {
+    support.info('click Areas Tab');
+    await this.areasTab.clickWhenReady();
+    await this.addAreasButton.untilDisplayed();
+    support.info('clicked Areas Tab');
+  }
+
+  async clickShowAreas() {
+    support.info('click show Areas');
+    await this.showAreasChildren.ready();
+    await this.showAreasChildren.untilClickable();
+    await this.showAreasChildren.clickWhenReady();
+    support.info('done - click show Areas');
+  }
+
+   async addAreas(areaName: string) {
+    support.info('Add areas');
+    await this.addAreasButton.clickWhenReady();
+    await this.createAreaDialog.untilDisplayed();
+    await this.areaInputField.enterText(areaName);
+    await this.createButton.clickWhenReady();
+    await this.createButton.untilTextIsPresent('Create');
+    await this.createAreaDialog.untilHidden();
+    await this.modalFade.untilHidden();
+    support.info('done - add areas');
+  }
+
+   /* Collaborators page*/
+  async clickCollaboratorsTab() {
+    support.info('click Collaborator Tab');
+    await this.collaboratorsTab.clickWhenReady();
+    await this.addCollaboratorsButton.untilDisplayed();
+    support.info('done - clicked Collaborators Tab');
+  }
+
+   async addCollaborators(userName: string) {
+    support.info('add collaborator');
+    await this.addCollaboratorsButton.clickWhenReady();
+    await this.collaboratorDialog.untilDisplayed();
+    await this.searchCollaborator.untilClickable();
+    await this.searchCollaborator.clickWhenReady();
+    await this.searchCollaborator.enterText(userName);
+    await this.collaboratorDropdown.untilDisplayed();
+    await this.searchCollaborator.sendKeys(Key.ENTER);
+    await this.addButton.clickWhenReady();
+    await this.addButton.untilHidden();
+    await this.modal.untilHidden();
+    support.info('done - add collaborators');
+  }
+
+   async getCollaboratorList(): Promise<String> {
+    let collaboratorList = await this.list.getText();
+    return collaboratorList.toString().replace('\n', '');
+  }
+
+  getUserInfo() {
+    return this.userInfo.getText();
+  }
+}

--- a/ee_tests/src/page_objects/user_profile.page.ts
+++ b/ee_tests/src/page_objects/user_profile.page.ts
@@ -1,6 +1,6 @@
-import { $, browser, by, element, ExpectedConditions as until } from 'protractor';
+import { $, browser, by,  element, ExpectedConditions as until } from 'protractor';
 import * as support from '../support';
-import { BaseElement } from '../ui/base.element';
+import { BaseElement, Clickable } from '../ui/base.element';
 import { Button } from '../ui/button';
 import { ModalDialog } from '../ui/modal_dialog';
 import { TextInput } from '../ui/text_input';
@@ -132,6 +132,16 @@ export class UserProfilePage extends AppPage {
     let page =  new EditUserProfilePage();
     await page.open();
     return page;
+  }
+}
+
+export class WorkItemCard extends AppPage {
+  workItemsCard = new BaseElement($('alm-work-items'), 'work item card');
+
+  async clickWorkItemTitle(title: string) {
+    let workitem = new Clickable(element(by.xpath(
+        "//span[contains(@class,'work-item-title')]//a[text()=' " + title + " ']")));
+  await workitem.clickWhenReady();
   }
 
 }

--- a/ee_tests/src/planner.spec.ts
+++ b/ee_tests/src/planner.spec.ts
@@ -1,0 +1,110 @@
+import { WorkItemCard } from './page_objects/user_profile.page';
+import { PlannerPage } from 'planner-functional-test';
+import { Header } from './page_objects/app/header';
+import { $, browser } from 'protractor';
+import * as support from './support';
+import { SpaceSettings } from './page_objects/space_settings.page';
+import { LoginInteractionsFactory } from './interactions/login_interactions';
+import { AccountHomeInteractionsFactory } from './interactions/account_home_interactions';
+
+describe('Planner EE tests adding Area and Collaborator', () => {
+  let planner = new PlannerPage(browser.baseUrl),
+    settingsPage = new SpaceSettings(),
+    header = new Header($('f8-app')),
+    workItemCard = new WorkItemCard(),
+    spaceName = support.newSpaceName();
+
+  beforeAll( async () => {
+    support.info('-------before All-------');
+    await support.desktopTestSetup();
+    let loginInteractions = LoginInteractionsFactory.create();
+    await loginInteractions.login();
+    let accountHomeInteractions = AccountHomeInteractionsFactory.create();
+    await accountHomeInteractions.createSpace(spaceName);
+  });
+
+  beforeEach(async() => {
+    support.screenshotManager.nextTest();
+  });
+
+  afterEach(async () => {
+    await support.screenshotManager.save('afterEach');
+  });
+
+  it('should Navigate to settings, add New Area and assign it to a workitem ', async () => {
+    support.specTitle('should add child area and Add it to a workitem');
+    let areaName = 'New Area',
+      area = '/' + spaceName + '/' + areaName;
+    // Navigate to settings, add Area
+    await settingsPage.clickSettings();
+    await planner.waitUntilUrlContains('settings');
+    expect(await browser.getCurrentUrl()).toContain('settings');
+    await settingsPage.list.untilCount(1);
+    expect(await settingsPage.list.getText()).toContain(spaceName);
+    await settingsPage.addAreas(areaName);
+    await settingsPage.clickShowAreas();
+    expect(await settingsPage.list.getText()).toContain('New Area');
+
+    // Click Plan tab, Create a new work Item and Add new Area
+    let workitemname = {'title': 'area test'};
+    await planner.planTab.untilClickable();
+    await planner.planTab.clickWhenReady();
+    await planner.waitUntilTitleContains('Plan');
+    await planner.ready();
+    await planner.createWorkItem(workitemname);
+    expect(planner.workItemList.hasWorkItem(workitemname.title)).toBeTruthy();
+    await planner.workItemList.clickWorkItem(workitemname.title);
+    await planner.quickPreview.addArea(areaName);
+    expect(planner.quickPreview.getArea()).toBe(area);
+    await planner.quickPreview.close();
+  });
+
+  it('should Navigate to collaborators, add a new collaborator and assign it to a workitem ', async () => {
+    support.specTitle('should add collaborator and assign it to a workitem');
+    await settingsPage.clickSettings();
+    await planner.waitUntilUrlContains('settings');
+    await settingsPage.clickCollaboratorsTab();
+    await planner.waitUntilUrlContains('collaborators');
+    expect(await browser.getCurrentUrl()).toContain('collaborators');
+    await settingsPage.list.untilCount(1);
+    await settingsPage.addCollaborators('Osio10');
+    await settingsPage.list.untilCount(2);
+    expect(await settingsPage.getCollaboratorList()).toContain('Osio10');
+
+    // Click Plan tab, Create a new work Item and Assign it to Collaborator
+    let workitemname = {'title': 'collaborator test'};
+    await planner.planTab.untilClickable();
+    await planner.planTab.clickWhenReady();
+    await planner.ready();
+    await planner.waitUntilTitleContains('Plan');
+    await planner.createWorkItem(workitemname);
+    expect(planner.workItemList.hasWorkItem(workitemname.title)).toBeTruthy();
+    await planner.workItemList.clickWorkItem(workitemname.title);
+    await planner.quickPreview.titleInput.untilTextIsPresentInValue(workitemname.title);
+    await planner.quickPreview.addAssignee('Osio10');
+    expect(planner.quickPreview.getAssignees()).toContain('Osio10');
+    await planner.quickPreview.close();
+  });
+
+  it('should assign a workitem, open profile page, and navigate from my work item to detail page', async() => {
+    support.specTitle('should add collaborator and assign it to a workitem');
+    // Create a workitem and self-assign it
+    let workitem = {'title': 'My workitem tests from profile page'};
+    await planner.clickPlanTab();
+    await planner.createWorkItem(workitem);
+    let userName = await settingsPage.getUserInfo();
+    expect(await planner.workItemList.hasWorkItem(workitem.title)).toBeTruthy();
+    await planner.workItemList.clickWorkItem(workitem.title);
+    await planner.quickPreview.addAssignee(userName + ' (me)');
+    expect(await planner.quickPreview.getAssignees()).toContain(userName);
+    await planner.quickPreview.close();
+
+    // Go to My work item in Profile page and click on a workitem to open detail page
+    await header.profileDropdown.select('Profile');
+    await planner.waitUntilUrlContains('_profile');
+    await workItemCard.clickWorkItemTitle(workitem.title);
+    await planner.waitUntilUrlContains('plan');
+    await planner.waitUntilTitleContains('plan');
+    expect(planner.detailPage.getAssignees()).toBe(userName);
+  });
+});


### PR DESCRIPTION
This PR adds Integration tests for Planner -
- creating child areas and adding it to a workitem
- Opening Assigned workitem from profile page
- adding collaborator and assigning it a workitem

Planner page object are shared and reused for Integration tests
Planner page objects - https://www.npmjs.com/package/planner-functional-test
The package is published from - https://github.com/fabric8-ui/fabric8-planner/pull/2779
and soon this PR will be merged in planner master.
 
Areas tests for prod-preview will fail 
open issue- https://github.com/openshiftio/openshift.io/issues/4366