### PR TITLE
e2e: failures reporter created

### DIFF
--- a/ee_tests/protractor.config.ts
+++ b/ee_tests/protractor.config.ts
@@ -2,6 +2,7 @@ import { browser, Config } from 'protractor';
 import { SpecReporter } from 'jasmine-spec-reporter';
 import * as failFast from 'protractor-fail-fast';
 import * as VideoReporter from 'protractor-video-reporter';
+import { FailuresReporter } from './src/support/failures_reporter';
 import { ZabbixReporter } from './src/support/zabbix_reporter';
 import * as support from './src/support';
 
@@ -96,6 +97,8 @@ let conf: Config = {
     if (useVideoReporter) {
       jasmine.getEnv().addReporter(videoReporter);
     }
+
+    jasmine.getEnv().addReporter(new FailuresReporter());
 
     if (browser.params.zabbix.enabled === 'true') {
       jasmine.getEnv().addReporter(new ZabbixReporter());

--- a/ee_tests/src/support/failures_reporter.ts
+++ b/ee_tests/src/support/failures_reporter.ts
@@ -1,0 +1,33 @@
+import CustomReporter = jasmine.CustomReporter;
+import CustomReporterResult = jasmine.CustomReporterResult;
+import { createWriteStream } from 'fs';
+import { sync as mkdirp } from 'mkdirp';
+
+/**
+ * When suite fails, it stores the error message in a file.
+ */
+export class FailuresReporter implements CustomReporter {
+
+    private readonly OUTPUT_DIRECTORY = 'target/screenshots/';
+
+    private suiteName = '';
+
+    public suiteStarted(result: CustomReporterResult) {
+        this.suiteName = result.description;
+    }
+
+    public specDone(result: CustomReporterResult) {
+        if (result.failedExpectations && result.failedExpectations.length > 0) {
+            mkdirp(this.OUTPUT_DIRECTORY);
+
+            let stream = createWriteStream(this.OUTPUT_DIRECTORY + 'failures.txt');
+
+            stream.write(this.suiteName + ' > ' + result.description + '\n');
+
+            for (let expectation of result.failedExpectations) {
+                stream.write(new Buffer(expectation.message + '\n'));
+            }
+            stream.end();
+        }
+    }
+}


### PR DESCRIPTION
1. it stores report to `target/screenshots`, this will be fixed in some other PR
2. it creates the file in `specDone` instead of `suiteDone` because `suiteDone` doesn't have these data, I guess that it is related to fail fast plugin that we use