### PR TITLE
e2e: tagging of local docker images improved

### DIFF
--- a/ee_tests/package.json
+++ b/ee_tests/package.json
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "postinstall": "npm run webdriver:update",
-    "image:build": "docker build -t fabric8-test:latest -f Dockerfile.builder .",
+    "image:build": "docker build -t fabric8-test -t fabric8-test:$(date +%s) -f Dockerfile.builder .",
     "image:start": "./local_cico_run_e2e_tests.sh",
     "protractor": "protractor",
     "start": ". config/local_osio.conf.sh && rm -rf target && ./ts-protractor.sh",


### PR DESCRIPTION
After running `npm run image:build` multiple times (always with some change), user ends up with something like this:
```
$ docker images     
REPOSITORY                      TAG                 IMAGE ID            CREATED             SIZE
fabric8-test                   latest              bb561ff9c077        6 hours ago         1.15 GB
<none>                      <none>              28773a37435b        6 hours ago         1.15 GB
<none>                      <none>              a05286f41e49        24 hours ago        1.15 GB
<none>                      <none>              9af360fcf850        26 hours ago        1.14 GB
<none>                      <none>              0574c488674e        47 hours ago        1.14 GB
<none>                      <none>              d76b17b045f4        2 days ago          1.15 GB
```

It is not clear what are these unnamed images, this PR fixes it to something like this:
```
$ docker images
REPOSITORY                TAG                 IMAGE ID            CREATED              SIZE
fabric8-test              1541086117          369ec1b2af4f        3 seconds ago        1.14 GB
fabric8-test              latest              369ec1b2af4f        3 seconds ago        1.14 GB
fabric8-test              1541086048          a9b3063a2ba9        About a minute ago   1.14 GB
fabric8-test              1541085997          961805ab8deb        About a minute ago   1.14 GB
```