### PR TITLE
e2e: small fixes in launcher page object and interactions

### DIFF
--- a/ee_tests/src/interactions/launcher_interactions.ts
+++ b/ee_tests/src/interactions/launcher_interactions.ts
@@ -124,7 +124,7 @@ class LauncherInteractionsImpl implements LauncherInteractions {
         expect(await summaryPage.getLocation()).toBe(specContext.getGitHubUser(), 'GitHub location');
         expect(await summaryPage.getRepository()).toBe(name, 'GitHub repository');
         await screenshotManager.save('launcher-summary');
-        await summaryPage.clickSetuUp();
+        await summaryPage.clickSetUp();
     }
 
     private async resultPageStep(): Promise<void> {

--- a/ee_tests/src/page_objects/launcher.page.ts
+++ b/ee_tests/src/page_objects/launcher.page.ts
@@ -156,12 +156,12 @@ export class SummaryPage {
         return this.getLabeledValue('Repository');
     }
 
-    async clickSetuUp(): Promise<void> {
-        return this.clickProjectSumamryButton('Set Up Application');
+    async clickSetUp(): Promise<void> {
+        await this.clickProjectSummaryButton('Set Up Application');
     }
 
     async clickImport(): Promise<void> {
-        return this.clickProjectSumamryButton('Import Application');
+        await this.clickProjectSummaryButton('Import Application');
     }
 
     private async getLabeledInputValue(label: string): Promise<string> {
@@ -186,7 +186,7 @@ export class SummaryPage {
         return parentElement.element(by.css(siblingCSS));
     }
 
-    private async clickProjectSumamryButton(description: string): Promise<void> {
+    private async clickProjectSummaryButton(description: string): Promise<void> {
         let projectSummaryButton = new Button(
             this.sectionElement.element(by.id('ProjectSummary')).element(by.tagName('button')),
             description


### PR DESCRIPTION
1. fixed couple of typos in function names
2. await instead of return, should fix random failures in tests such as https://ci.centos.org/job/devtools-test-e2e-prod-preview.openshift.io-smoketest-pr-us-east-2a-beta/3602/console