### PR TITLE
e2e: log only names of che workspaces, no space names

### DIFF
--- a/ee_tests/oc-get-project-logs.sh
+++ b/ee_tests/oc-get-project-logs.sh
@@ -86,7 +86,7 @@ if [ "$3" == "che" ] && [ ! -z "$4" ]; then
     "$CHE_SERVER_URL/api/workspace?maxItems=1000")
   echo "Number of existing workspaces: $(echo $RESPONSE | jq '. | length')"
   echo "List of existing workspaces:"
-  echo $RESPONSE | jq '.[] | {workspace_name: .config.name, project_name: .config.projects[].name}'
+  echo $RESPONSE | jq '.[] | .config.name'
 fi
 
 echo ---------- Script finished -------------------------


### PR DESCRIPTION
Old logs in `./target/screenshots/oc-che-logs.txt`

```
Number of existing workspaces: 45
List of existing workspaces:
{
  "workspace_name": "e2e-0121-0037-162-egznb",
  "project_name": "e2e-0121-0037-162"
}
{
  "workspace_name": "e2e-0120-0237-3764-wba8n",
  "project_name": "e2e-0120-0237-3764"
}
...
```

New

```
Number of existing workspaces: 45
List of existing workspaces:
"e2e-0121-0037-162-egznb"
"e2e-0120-0237-3764-wba8n"
...
```