### PR TITLE
e2e: Change create workspace selector

### DIFF
--- a/ee_tests/src/page_objects/space_codebases.page.ts
+++ b/ee_tests/src/page_objects/space_codebases.page.ts
@@ -16,7 +16,7 @@ export class CodebasesPage extends AppPage {
   }
 
   public async createWorkspace() {
-    let createCodebase = new Button(element(by.xpath('.//codebases-item-workspaces')), 'Create Codespace...');
+    let createCodebase = new Button(element(by.xpath('.//codebases-item-workspaces/a')), 'Create Codespace...');
     await createCodebase.clickWhenReady(timeouts.LONGER_WAIT);
     await browser.wait(until.presenceOf(element(this.openButtonLocator)));
   }


### PR DESCRIPTION
Possible fix for https://github.com/openshiftio/openshift.io/issues/4720

The e2e tests try to click on the outer div (green colored) while the achor tag is on the text inside the div (yellow color). With this PR, the e2e tests will click on the yellow text instead of the green div.

![screenshot from 2019-01-22 10-38-33](https://user-images.githubusercontent.com/12949454/51513654-fa1dd280-1e31-11e9-9214-937eed6635c4.png)

