### PR TITLE
Use Radon 2.4.0 instead of 3.0.0

### DIFF
--- a/self_tests/measure-cyclomatic-complexity.sh
+++ b/self_tests/measure-cyclomatic-complexity.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function prepare_venv() {
-    python3 -m venv venv && source venv/bin/activate && python3 "$(which pip3)" install radon
+    python3 -m venv venv && source venv/bin/activate && python3 "$(which pip3)" install radon==2.4.0
 }
 
 [ "$NOVENV" == "1" ] || prepare_venv || exit 1

--- a/self_tests/measure-maintainability-index.sh
+++ b/self_tests/measure-maintainability-index.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function prepare_venv() {
-    python3 -m venv venv && source venv/bin/activate && python3 "$(which pip3)" install radon
+    python3 -m venv venv && source venv/bin/activate && python3 "$(which pip3)" install radon==2.4.0
 }
 
 [ "$NOVENV" == "1" ] || prepare_venv || exit 1


### PR DESCRIPTION
Let's use the older Radon 2.4.0 instead of 3.0.0. We'll need to wait for fix for the following issue to use 3.0.0:
https://github.com/rubik/radon/issues/166